### PR TITLE
PING/PONG

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -40,7 +40,7 @@ defmodule Gnat do
   defp process_message({:msg, topic, sid, body}, state) do
     send state.receivers[sid], {:msg, topic, body}
   end
-  defp process_message("PING", state) do
+  defp process_message(:ping, state) do
     :gen_tcp.send(state.tcp, "PONG\r\n")
   end
   def handle_info({:tcp, tcp, data}, %{tcp: tcp, parser: parser}=state) do

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -37,11 +37,16 @@ defmodule Gnat do
     end
   end
 
+  defp process_message({:msg, topic, sid, body}, state) do
+    send state.receivers[sid], {:msg, topic, body}
+  end
+  defp process_message("PING", state) do
+    :gen_tcp.send(state.tcp, "PONG\r\n")
+  end
   def handle_info({:tcp, tcp, data}, %{tcp: tcp, parser: parser}=state) do
+    Logger.debug "#{__MODULE__} received #{inspect data}"
     {new_parser, messages} = Parser.parse(parser, data)
-    Enum.each(messages, fn({:msg, topic, sid, body}) ->
-      send state.receivers[sid], {:msg, topic, body}
-    end)
+    Enum.each(messages, &process_message(&1, state))
     {:noreply, %{state | parser: new_parser}}
   end
   def handle_info(other, state) do

--- a/lib/gnat/parser.ex
+++ b/lib/gnat/parser.ex
@@ -1,4 +1,5 @@
 defmodule Gnat.Parser do
+  require Logger
   # states: waiting, reading_message
   defstruct [
     partial: "",
@@ -12,6 +13,7 @@ defmodule Gnat.Parser do
   end
 
   def parse(parser, "", parsed), do: {parser, Enum.reverse(parsed)}
+  def parse(parser, "PING\r\n", _), do: {parser, ["PING"]}
   def parse(parser, bytes, parsed) do
     {index, 2} = :binary.match(bytes, "\r\n")
     {command, "\r\n"<>rest} = String.split_at(bytes, index)

--- a/lib/gnat/parser.ex
+++ b/lib/gnat/parser.ex
@@ -13,7 +13,7 @@ defmodule Gnat.Parser do
   end
 
   def parse(parser, "", parsed), do: {parser, Enum.reverse(parsed)}
-  def parse(parser, "PING\r\n", _), do: {parser, ["PING"]}
+  def parse(parser, "PING\r\n", _), do: {parser, [:ping]}
   def parse(parser, bytes, parsed) do
     {index, 2} = :binary.match(bytes, "\r\n")
     {command, "\r\n"<>rest} = String.split_at(bytes, index)

--- a/test/gnat/parser_test.exs
+++ b/test/gnat/parser_test.exs
@@ -20,4 +20,10 @@ defmodule Gnat.ParserTest do
     assert msg1 == {:msg, "t1", 1, "wat"}
     assert msg2 == {:msg, "t2", 2, "dawg"}
   end
+
+  test "parsing PING message" do
+    {parser_state, [parsed_message]} = Parser.new |> Parser.parse("PING\r\n")
+    assert parser_state.partial == ""
+    assert parsed_message == "PING"
+  end
 end

--- a/test/gnat/parser_test.exs
+++ b/test/gnat/parser_test.exs
@@ -24,6 +24,6 @@ defmodule Gnat.ParserTest do
   test "parsing PING message" do
     {parser_state, [parsed_message]} = Parser.new |> Parser.parse("PING\r\n")
     assert parser_state.partial == ""
-    assert parsed_message == "PING"
+    assert parsed_message == :ping
   end
 end


### PR DESCRIPTION
This will reply to server `PING` messages.

This is the first iteration.  There is another PR with a different solution.

PROS:

  * Simpler parser
  * Message isn't "misrepresented" from the parser.  It returns just the `PING`, not manufacturing fake `sid` or `body`

CONS:
  * Handler is a little funky.  Since the message is a different format, it requires a bit more work in the handler to deal with the differences.

Resolves #12

/cc @newellista @tallguy-hackett @jjcarstens