### PR TITLE
PING/PONG -- Take #2

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -40,7 +40,13 @@ defmodule Gnat do
   def handle_info({:tcp, tcp, data}, %{tcp: tcp, parser: parser}=state) do
     {new_parser, messages} = Parser.parse(parser, data)
     Enum.each(messages, fn({:msg, topic, sid, body}) ->
-      send state.receivers[sid], {:msg, topic, body}
+      case topic do
+        "PING" ->
+          Logger.debug "#{__MODULE__} Received PING, sending PONG"
+          :gen_tcp.send(state.tcp, "PONG\r\n")
+        _ ->
+          send state.receivers[sid], {:msg, topic, body}
+      end
     end)
     {:noreply, %{state | parser: new_parser}}
   end

--- a/lib/gnat/parser.ex
+++ b/lib/gnat/parser.ex
@@ -12,6 +12,7 @@ defmodule Gnat.Parser do
   end
 
   def parse(parser, "", parsed), do: {parser, Enum.reverse(parsed)}
+  def parse(parser, "PING\r\n", _), do: {parser, [{:msg, "PING", "", ""}]}
   def parse(parser, bytes, parsed) do
     {index, 2} = :binary.match(bytes, "\r\n")
     {command, "\r\n"<>rest} = String.split_at(bytes, index)

--- a/test/gnat/parser_test.exs
+++ b/test/gnat/parser_test.exs
@@ -20,4 +20,10 @@ defmodule Gnat.ParserTest do
     assert msg1 == {:msg, "t1", 1, "wat"}
     assert msg2 == {:msg, "t2", 2, "dawg"}
   end
+  
+  test "parsing PING message" do
+    {parser_state, [parsed_message]} = Parser.new |> Parser.parse("PING\r\n")
+    assert parser_state.partial == ""
+    assert parsed_message == {:msg, "PING", "", ""}
+  end
 end


### PR DESCRIPTION
This is the second implementation handling PING/PONG.

It feels a little cleaner, and the code is a bit simpler.

EXCEPT:

The parser generates an "artificial" message containing empty `sid` and `body` fields.  Probably not a big deal, but looks a little strange.

Anybody have any feedback on a possible **third** solution that is more idiomatic?

Resolves #12 

/cc @newellista @tallguy-hackett @jjcarstens