### PR TITLE
Unsub with max msgs

### DIFF
--- a/lib/gnat/command.ex
+++ b/lib/gnat/command.ex
@@ -1,0 +1,7 @@
+defmodule Gnat.Command do
+  @newline "\r\n"
+  @unsub "UNSUB"
+
+  def build(:unsub, sid, []), do: [@unsub, " #{sid}", @newline]
+  def build(:unsub, sid, [max_messages: max]), do: [@unsub, " #{sid}", " #{max}", @newline]
+end

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -1,0 +1,14 @@
+defmodule Gnat.CommandTest do
+  use ExUnit.Case, async: true
+  alias Gnat.Command
+
+  test "formatting a simple unsub message" do
+    command = Command.build(:unsub, 12, []) |> IO.iodata_to_binary
+    assert command == "UNSUB 12\r\n"
+  end
+
+  test "formatting an unsub message with max messages" do
+    command = Command.build(:unsub, 12, [max_messages: 3]) |> IO.iodata_to_binary
+    assert command == "UNSUB 12 3\r\n"
+  end
+end

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -43,4 +43,20 @@ defmodule GnatTest do
       after 200 -> :ok
     end
   end
+
+  test "unsubscribing from a topic after a maximum number of messages" do
+    topic = "testunsub_maxmsg"
+    {:ok, pid} = Gnat.start_link()
+    {:ok, sub_ref} = Gnat.sub(pid, self(), topic)
+    :ok = Gnat.unsub(pid, sub_ref, max_messages: 2)
+    :ok = Gnat.pub(pid, topic, "msg1")
+    :ok = Gnat.pub(pid, topic, "msg2")
+    :ok = Gnat.pub(pid, topic, "msg3")
+    assert_receive {:msg, ^topic, "msg1"}, 500
+    assert_receive {:msg, ^topic, "msg2"}, 500
+    receive do
+      {:msg, _topic, _msg}=msg -> flunk("Received message after unsubscribe: #{inspect msg}")
+      after 200 -> :ok
+    end
+  end
 end


### PR DESCRIPTION
Getting a little further with #8 

This PR adds support for doing an `UNSUB` with a maximum number of messages. I decided to make the maximum messages be part of an optional 3rd parameter which comes in as a keyword list. This seems to match a common pattern for APIs in the elixir community. Right now this is the only optional parameter to an unsub command in the NATS protocol, but I imagine that could change in the future so I figured modeling it as a keyword list kept things flexible for the future.

I also didn't want to add multiple `handle_call` clauses or private functions to the `gnat.ex` so I decided to extract the formatting of on-the-wire commands into a separate module.