### PR TITLE
Start documentation

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -24,6 +24,22 @@ defmodule Gnat do
 
   def pub(pid, topic, message), do: GenServer.call(pid, {:pub, topic, message})
 
+  @doc """
+  Unsubscribe from a topic
+
+  This correlates to the [UNSUB](http://nats.io/documentation/internals/nats-protocol/#UNSUB) command in the nats protocol.
+  By default the unsubscribe is affected immediately, but an optional `max_messages` value can be provided which will allow
+  `max_messages` to be received before affecting the unsubscribe.
+  This is especially useful for [request response](http://nats.io/documentation/concepts/nats-req-rep/) patterns.
+
+  ```
+  {:ok, gnat} = Gnat.start_link()
+  {:ok, subscription} = Gnat.sub(gnat, self(), "my_inbox")
+  :ok = Gnat.unsub(gnat, subscription)
+  # OR
+  :ok = Gnat.unsub(gnat, subscription, max_messages: 2)
+  ```
+  """
   def unsub(pid, sid, opts \\ []), do: GenServer.call(pid, {:unsub, sid, opts})
 
   def init(connection_settings) do

--- a/mix.exs
+++ b/mix.exs
@@ -17,6 +17,7 @@ defmodule Gnat.Mixfile do
   defp deps do
     [
       {:benchee, "~> 0.6.0", only: :dev},
+      {:ex_doc, "~> 0.15", only: :dev},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,4 @@
 %{"benchee": {:hex, :benchee, "0.6.0", "c2565506c621ee010e71d05f555e39a1b937e00810e284bc85463a4d4efc4b00", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, optional: false]}]},
-  "deep_merge": {:hex, :deep_merge, "0.1.1", "c27866a7524a337b6a039eeb8dd4f17d458fd40fbbcb8c54661b71a22fffe846", [:mix], []}}
+  "deep_merge": {:hex, :deep_merge, "0.1.1", "c27866a7524a337b6a039eeb8dd4f17d458fd40fbbcb8c54661b71a22fffe846", [:mix], []},
+  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]}}


### PR DESCRIPTION
Building off of #19, this PR starts to set up some documentation for the project. It adds `ex_doc` as a development dependency and adds a doc string for the `Gnat.unsub/3` function which looks like this when it is rendered:

![screen shot 2017-03-24 at 6 41 21 am](https://cloud.githubusercontent.com/assets/80008/24294692/30b45934-105d-11e7-8e1e-e4e336c6e527.png)