### PR TITLE
Pub with reply

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -22,7 +22,7 @@ defmodule Gnat do
 
   def sub(pid, subscriber, topic), do: GenServer.call(pid, {:sub, subscriber, topic})
 
-  def pub(pid, topic, message), do: GenServer.call(pid, {:pub, topic, message})
+  def pub(pid, topic, message, opts \\ []), do: GenServer.call(pid, {:pub, topic, message, opts})
 
   @doc """
   Unsubscribe from a topic
@@ -83,9 +83,9 @@ defmodule Gnat do
     next_state = Map.merge(state, %{receivers: receivers, next_sid: sid + 1})
     {:reply, {:ok, sid}, next_state}
   end
-  def handle_call({:pub, topic, message}, _from, state) do
-    publish_data = [["PUB ", topic, " #{IO.iodata_length(message)}\r\n"], [message, "\r\n"]]
-    :ok = :gen_tcp.send(state.tcp, publish_data)
+  def handle_call({:pub, topic, message, opts}, _from, state) do
+    command = Command.build(:pub, topic, message, opts)
+    :ok = :gen_tcp.send(state.tcp, command)
     {:reply, :ok, state}
   end
   def handle_call({:unsub, sid, opts}, _from, state) do

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -55,8 +55,8 @@ defmodule Gnat do
     end
   end
 
-  defp process_message({:msg, topic, sid, body}, state) do
-    send state.receivers[sid], {:msg, topic, body}
+  defp process_message({:msg, topic, sid, reply_to, body}, state) do
+    send state.receivers[sid], {:msg, %{topic: topic, body: body, reply_to: reply_to}}
   end
   defp process_message(:ping, state) do
     :gen_tcp.send(state.tcp, "PONG\r\n")

--- a/lib/gnat/command.ex
+++ b/lib/gnat/command.ex
@@ -1,6 +1,10 @@
 defmodule Gnat.Command do
   @newline "\r\n"
+  @pub "PUB"
   @unsub "UNSUB"
+
+  def build(:pub, topic, payload, []), do: [@pub, " ", topic, " #{IO.iodata_length(payload)}", @newline, payload, @newline]
+  def build(:pub, topic, payload, [reply_to: reply]), do: [@pub, " ", topic, " ", reply, " #{IO.iodata_length(payload)}", @newline, payload, @newline]
 
   def build(:unsub, sid, []), do: [@unsub, " #{sid}", @newline]
   def build(:unsub, sid, [max_messages: max]), do: [@unsub, " #{sid}", " #{max}", @newline]

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -2,6 +2,16 @@ defmodule Gnat.CommandTest do
   use ExUnit.Case, async: true
   alias Gnat.Command
 
+  test "formatting a simple pub message" do
+    command = Command.build(:pub, "topic", "payload", []) |> IO.iodata_to_binary
+    assert command == "PUB topic 7\r\npayload\r\n"
+  end
+
+  test "formatting a pub with reply_to set" do
+    command = Command.build(:pub, "topic", "payload", [reply_to: "INBOX"]) |> IO.iodata_to_binary
+    assert command == "PUB topic INBOX 7\r\npayload\r\n"
+  end
+
   test "formatting a simple unsub message" do
     command = Command.build(:unsub, 12, []) |> IO.iodata_to_binary
     assert command == "UNSUB 12\r\n"

--- a/test/gnat/parser_test.exs
+++ b/test/gnat/parser_test.exs
@@ -5,20 +5,26 @@ defmodule Gnat.ParserTest do
   test "parsing a complete message" do
     {parser_state, [parsed_message]} = Parser.new |> Parser.parse("MSG topic 13 4\r\ntest\r\n")
     assert parser_state.partial == ""
-    assert parsed_message == {:msg, "topic", 13, "test"}
+    assert parsed_message == {:msg, "topic", 13, nil, "test"}
   end
 
   test "parsing a complete message with newlines in it" do
     {parser_state, [parsed_message]} = Parser.new |> Parser.parse("MSG topic 13 10\r\ntest\r\nline\r\n")
     assert parser_state.partial == ""
-    assert parsed_message == {:msg, "topic", 13, "test\r\nline"}
+    assert parsed_message == {:msg, "topic", 13, nil, "test\r\nline"}
   end
 
   test "parsing multiple messages" do
     {parser_state, [msg1,msg2]} = Parser.new |> Parser.parse("MSG t1 1 3\r\nwat\r\nMSG t2 2 4\r\ndawg\r\n")
     assert parser_state.partial == ""
-    assert msg1 == {:msg, "t1", 1, "wat"}
-    assert msg2 == {:msg, "t2", 2, "dawg"}
+    assert msg1 == {:msg, "t1", 1, nil, "wat"}
+    assert msg2 == {:msg, "t2", 2, nil, "dawg"}
+  end
+
+  test "parsing a message with a reply to" do
+    {parser_state, [parsed_message]} = Parser.new |> Parser.parse("MSG topic 13 me 10\r\ntest\r\nline\r\n")
+    assert parser_state.partial == ""
+    assert parsed_message == {:msg, "topic", 13, "me", "test\r\nline"}
   end
 
   test "parsing PING message" do

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -20,9 +20,9 @@ defmodule GnatTest do
   test "subscribe receive a message with a reply_to" do
     {:ok, pid} = Gnat.start_link()
     {:ok, _ref} = Gnat.sub(pid, self(), "with_reply")
-    :ok = Gnat.pub(pid, "reply_to", "yo dawg", reply_to: "me")
+    :ok = Gnat.pub(pid, "with_reply", "yo dawg", reply_to: "me")
 
-    assert_receive {:msg, %{topic: "test", reply_to: "me", body: "yo dawg"}}, 1000
+    assert_receive {:msg, %{topic: "with_reply", reply_to: "me", body: "yo dawg"}}, 1000
     :ok = Gnat.stop(pid)
   end
 


### PR DESCRIPTION
Support for passing a `reply_to` and receiving messages with a `reply_to` value. This is a pre-requisite for #10

In order to support this I needed to change the format of how we deliver messages to subscribed processes. Instead of passing another element in a tuple (I always forget which order the items are in) I changed it to passing a map so you can pattern match in a more readable way.

This is a YOLO breaking change, but we haven't even published to hex.pm so :man_shrugging: :woman_shrugging: 

/cc @newellista @quixoten @film42 @tallguy-hackett 