### PR TITLE
Request reply

### DIFF
--- a/bench.exs
+++ b/bench.exs
@@ -40,11 +40,7 @@ Benchee.run(%{
       after 100 -> raise "timed out on sub"
     end
   end,
-  "req-reply-16" => fn ->
-    {:ok, inbox} = Gnat.request(pid, "echo", "ping")
-    receive do
-      {:msg, %{topic: ^inbox, body: "pong"}} -> :ok
-      after 100 -> raise "didn't receive a pong"
-    end
+  "req-reply-4" => fn ->
+    {:ok, %{body: "pong"}} = Gnat.request(pid, "echo", "ping")
   end,
 }, time: 10, console: [comparison: false])

--- a/bench.exs
+++ b/bench.exs
@@ -1,30 +1,50 @@
+defmodule EchoServer do
+  def run(gnat) do
+    spawn(fn -> init(gnat) end)
+  end
+
+  def init(gnat) do
+    Gnat.sub(gnat, self(), "echo")
+    loop(gnat)
+  end
+
+  def loop(gnat) do
+    receive do
+      {:msg, %{topic: "echo", reply_to: reply_to, body: "ping"}} ->
+        Gnat.pub(gnat, reply_to, "pong")
+      other ->
+        IO.puts "server received: #{inspect other}"
+    end
+
+    loop(gnat)
+  end
+end
+
 {:ok, pid} = Gnat.start_link(%{host: '127.0.0.1', port: 4222})
+EchoServer.run(pid)
 
 msg128="74c93e71c5aa03ad4f0881caa374ba1af08f3e4a04ce5f8bd0b2d82d6d72de6eef3e46ed8d8c3dbe24d0f6109115dcdf13280d1c13c2f6d22d14336b29df8e65"
 msg16="74c93e71c5aa03ad"
 
-IO.puts "== Parsing tcp packets"
 tcp_packet = "MSG topic 1 128\r\n#{msg128}\r\n"
 Benchee.run(%{
-  "parse-128" => fn -> {_parser, [_msg]} = Gnat.Parser.new() |> Gnat.Parser.parse(tcp_packet) end
-}, time: 5)
-
-IO.puts "== Publish Throughput"
-Benchee.run(%{
+  "parse-128" => fn -> {_parser, [_msg]} = Gnat.Parser.new() |> Gnat.Parser.parse(tcp_packet) end,
   "pub - 128" => fn -> :ok = Gnat.pub(pid, "pub128", msg128) end,
-}, time: 5)
-
-IO.puts "== Subscribe -> Publish -> Receive Throughput"
-Benchee.run(%{
-  "subpub-16" => fn ->
-    rand = :crypto.strong_rand_bytes(4) |> Base.encode64
-    :ok = Gnat.sub(pid, self(), rand)
+  "sub-unsub-pub-16" => fn ->
+    rand = :crypto.strong_rand_bytes(8) |> Base.encode64
+    {:ok, subscription} = Gnat.sub(pid, self(), rand)
+    :ok = Gnat.unsub(pid, subscription, max_messages: 1)
     :ok = Gnat.pub(pid, rand, msg16)
     receive do
-      {:msg, ^rand, ^msg16} -> :ok
+      {:msg, %{topic: ^rand, body: ^msg16}} -> :ok
       after 100 -> raise "timed out on sub"
     end
   end,
-}, time: 10)
-
-Gnat.stop(pid)
+  "req-reply-16" => fn ->
+    {:ok, inbox} = Gnat.request(pid, "echo", "ping")
+    receive do
+      {:msg, %{topic: ^inbox, body: "pong"}} -> :ok
+      after 100 -> raise "didn't receive a pong"
+    end
+  end,
+}, time: 10, console: [comparison: false])

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,3 @@
 use Mix.Config
+
+config :logger, level: :info

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -24,6 +24,16 @@ defmodule Gnat do
 
   def pub(pid, topic, message, opts \\ []), do: GenServer.call(pid, {:pub, topic, message, opts})
 
+  @doc """
+  Send a request listen for response(s)
+
+  Following the nats [request-response pattern](http://nats.io/documentation/concepts/nats-req-rep/) this
+  function generates a one-time topic to receive replies and then sends a message to the provided topic.
+
+  Supported options:
+    * max_messages: how many messages to expect before cleaning up the inbox subscription (default `1`)
+    * recipient: which pid should receive the responses (default `self()`)
+  """
   def request(pid, topic, body, opts \\ []) do
     recipient = Keyword.get(opts, :recipient, self())
     max_messages = Keyword.get(opts, :max_messages, 1)

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -47,7 +47,6 @@ defmodule Gnat do
     {:ok, subscription} = GenServer.call(pid, {:request, %{recipient: self(), inbox: inbox, body: body, topic: topic}})
     receive do
       {:msg, %{topic: ^inbox}=msg} -> {:ok, msg}
-      other -> IO.inspect(other)
       after receive_timeout ->
         :ok = unsub(pid, subscription)
         {:error, :timeout}

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -73,8 +73,8 @@ defmodule GnatTest do
     topic = "req-resp"
     {:ok, pid} = Gnat.start_link()
     spin_up_echo_server_on_topic(pid, topic)
-    {:ok, inbox} = Gnat.request(pid, topic, "ohai")
-    assert_receive {:msg, %{body: "ohai", topic: ^inbox, reply_to: nil}}, 500
+    {:ok, msg} = Gnat.request(pid, topic, "ohai", receive_timeout: 500)
+    assert msg.body == "ohai"
   end
 
   defp spin_up_echo_server_on_topic(gnat, topic) do

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -68,4 +68,23 @@ defmodule GnatTest do
       after 200 -> :ok
     end
   end
+
+  test "request-reply convenience function" do
+    topic = "req-resp"
+    {:ok, pid} = Gnat.start_link()
+    spin_up_echo_server_on_topic(pid, topic)
+    {:ok, inbox} = Gnat.request(pid, topic, "ohai")
+    assert_receive {:msg, %{body: "ohai", topic: ^inbox, reply_to: nil}}, 500
+  end
+
+  defp spin_up_echo_server_on_topic(gnat, topic) do
+    spawn(fn ->
+      {:ok, subscription} = Gnat.sub(gnat, self(), topic)
+      :ok = Gnat.unsub(gnat, subscription, max_messages: 1)
+      receive do
+        {:msg, %{topic: ^topic, body: body, reply_to: reply_to}} ->
+          Gnat.pub(gnat, reply_to, body)
+      end
+    end)
+  end
 end


### PR DESCRIPTION
This introduces a helper function to make doing [request and reply](http://nats.io/documentation/concepts/nats-req-rep/) patterns easier and more efficient (ie by sending the sub, unsub and pub messages together in the same TCP packet).

I also updated the benchmark script and I currently get these numbers on my machine:

```
$ mix run bench.exs
Erlang/OTP 19 [erts-8.2] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
Elixir 1.4.1
Benchmark suite executing with the following configuration:
warmup: 2.0s
time: 10.0s
parallel: 1
inputs: none specified
Estimated total run time: 48.0s

Benchmarking parse-128...
Benchmarking pub - 128...
Benchmarking req-reply-16...
Benchmarking sub-unsub-pub-16...

Name                       ips        average  deviation         median
pub - 128              89.12 K       11.22 μs   ±117.84%       11.00 μs
parse-128              89.06 K       11.23 μs   ±173.47%       10.00 μs
sub-unsub-pub-16        8.55 K      116.96 μs    ±28.81%      111.00 μs
req-reply-16            5.83 K      171.55 μs    ±18.23%      165.00 μs
```

Doing 5,830 request-reply cycles in serial per second is 👌  in my book. We'll see how close we can stay to those numbers as we add more complete parsing and behavior.

/cc @film42 @newellista @jjcarstens @tallguy-hackett 