### PR TITLE
Case insensitive commands

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -96,8 +96,11 @@ defmodule Gnat do
 
   defp perform_handshake(tcp) do
     receive do
-      {:tcp, ^tcp, "INFO"<>_} ->
-        :gen_tcp.send(tcp, "CONNECT {\"verbose\": false}\r\n")
+      {:tcp, ^tcp, operation} ->
+        op_name = operation |> String.split |> List.first
+        if String.match?(op_name, ~r{info}i) do
+          :gen_tcp.send(tcp, "CONNECT {\"verbose\": false}\r\n")
+        end
       after 1000 ->
         {:error, "timed out waiting for info"}
     end

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -135,10 +135,8 @@ defmodule Gnat do
   defp perform_handshake(tcp) do
     receive do
       {:tcp, ^tcp, operation} ->
-        op_name = operation |> String.split |> List.first
-        if String.match?(op_name, ~r{info}i) do
-          :gen_tcp.send(tcp, "CONNECT {\"verbose\": false}\r\n")
-        end
+        "INFO" = operation |> String.split |> List.first |> String.upcase
+        :gen_tcp.send(tcp, "CONNECT {\"verbose\": false}\r\n")
       after 1000 ->
         {:error, "timed out waiting for info"}
     end

--- a/lib/gnat/parser.ex
+++ b/lib/gnat/parser.ex
@@ -21,16 +21,16 @@ defmodule Gnat.Parser do
     parse(parser, rest, parsed)
   end
 
-  defp parse_command(command_str, body) do
-    [command | details] = String.split(command_str)
-    cond do
-      String.match?(command, ~r{msg}i) -> parse_msg(details, body)
-      String.match?(command, ~r{ping}i) -> {:ping, ""}
-    end
+  defp parse_command(command, body) do
+    [operation | details] = String.split(command)
+    operation
+    |> String.upcase
+    |> parse_command(details, body)
   end
 
-  defp parse_msg([topic, sidstr, sizestr], body), do: parse_msg([topic, sidstr, nil, sizestr], body)
-  defp parse_msg([topic, sidstr, reply_to, sizestr], body) do
+  defp parse_command("PING", _, body), do: {:ping, body}
+  defp parse_command("MSG", [topic, sidstr, sizestr], body), do: parse_command("MSG", [topic, sidstr, nil, sizestr], body)
+  defp parse_command("MSG", [topic, sidstr, reply_to, sizestr], body) do
     sid = String.to_integer(sidstr)
     bytesize = String.to_integer(sizestr)
     << message :: binary-size(bytesize), "\r\n", rest :: binary >> = body

--- a/lib/gnat/parser.ex
+++ b/lib/gnat/parser.ex
@@ -24,9 +24,12 @@ defmodule Gnat.Parser do
   end
 
   defp parse_message_header(str) do
-    case String.split(str) do
-      ["MSG", topic, sidstr, sizestr] -> {topic, String.to_integer(sidstr), nil, String.to_integer(sizestr)}
-      ["MSG", topic, sidstr, reply_to, sizestr] -> {topic, String.to_integer(sidstr), reply_to, String.to_integer(sizestr)}
+    [command | details] = String.split(str)
+    cond do
+      String.match?(command, ~r{msg}i) -> parse_msg(details)
     end
   end
+
+  defp parse_msg([topic, sidstr, sizestr]), do: {topic, String.to_integer(sidstr), nil, String.to_integer(sizestr)}
+  defp parse_msg([topic, sidstr, reply_to, sizestr]), do: {topic, String.to_integer(sidstr), reply_to, String.to_integer(sizestr)}
 end

--- a/test/gnat/parser_test.exs
+++ b/test/gnat/parser_test.exs
@@ -32,4 +32,10 @@ defmodule Gnat.ParserTest do
     assert parser_state.partial == ""
     assert parsed_message == :ping
   end
+
+  test "parsing a complete message with case insensitive command" do
+    {parser_state, [parsed_message]} = Parser.new |> Parser.parse("msg topic 13 4\r\ntest\r\n")
+    assert parser_state.partial == ""
+    assert parsed_message == {:msg, "topic", 13, nil, "test"}
+  end
 end

--- a/test/gnat/parser_test.exs
+++ b/test/gnat/parser_test.exs
@@ -38,4 +38,10 @@ defmodule Gnat.ParserTest do
     assert parser_state.partial == ""
     assert parsed_message == {:msg, "topic", 13, nil, "test"}
   end
+
+  test "parsing case insensitive ping message" do
+    {parser_state, [parsed_message]} = Parser.new |> Parser.parse("ping\r\n")
+    assert parser_state.partial == ""
+    assert parsed_message == :ping
+  end
 end


### PR DESCRIPTION
This is my attempt at addressing Issue #18 with case insensitivity while parsing.  I split out some of the message parsing so that the case insensitivity check could work in the `cond` call and renamed a function to more appropriately describe parsing a (NATS) command.

I tried to find some kind of magic voodoo what would allow matching against a regex during a pattern match.  There wasn't anything really good.  The closest I found was using something a lot more complicated than I wanted to get into.  So I settled on using a `cond` to allow for regex match on the command name.