### PR TITLE
Sub (with support for queue groups)

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -119,7 +119,7 @@ defmodule Gnat do
     {:reply, :ok, state}
   end
   def handle_call({:request, request}, _from, %{next_sid: sid}=state) do
-    sub = ["SUB", " #{request.inbox} #{sid}", "\r\n"]
+    sub = Command.build(:sub, request.inbox, sid, [])
     unsub = Command.build(:unsub, sid, [max_messages: 1])
     pub = Command.build(:pub, request.topic, request.body, reply_to: request.inbox)
     receivers = Map.put(state.receivers, sid, request.recipient)

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -24,8 +24,8 @@ defmodule Gnat do
   Subscribe to a topic
 
   By default each subscriber will receive a copy of messages on the topic.
-  When a queue_group is supplied messages will be spread amongs the subscribers
-  int the same group. (see [nats queueing](https://nats.io/documentation/concepts/nats-queueing/))
+  When a queue_group is supplied messages will be spread among the subscribers
+  in the same group. (see [nats queueing](https://nats.io/documentation/concepts/nats-queueing/))
 
   Supported options:
     * queue_group: a string that identifies which queue group you want to join

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -20,6 +20,25 @@ defmodule Gnat do
 
   def stop(pid), do: GenServer.call(pid, :stop)
 
+  @doc """
+  Subscribe to a topic
+
+  By default each subscriber will receive a copy of messages on the topic.
+  When a queue_group is supplied messages will be spread amongs the subscribers
+  int the same group. (see [nats queueing](https://nats.io/documentation/concepts/nats-queueing/))
+
+  Supported options:
+    * queue_group: a string that identifies which queue group you want to join
+
+  ```
+  {:ok, gnat} = Gnat.start_link()
+  {:ok, subscription} = Gnat.sub(gnat, "topic")
+  receive do
+    {:msg, %{topic: "topic", body: body}} ->
+      IO.puts "Received: \#\{body\}"
+  end
+  ```
+  """
   def sub(pid, subscriber, topic, opts \\ []), do: GenServer.call(pid, {:sub, subscriber, topic, opts})
 
   def pub(pid, topic, message, opts \\ []), do: GenServer.call(pid, {:pub, topic, message, opts})

--- a/lib/gnat/command.ex
+++ b/lib/gnat/command.ex
@@ -1,10 +1,14 @@
 defmodule Gnat.Command do
   @newline "\r\n"
   @pub "PUB"
+  @sub "SUB"
   @unsub "UNSUB"
 
   def build(:pub, topic, payload, []), do: [@pub, " ", topic, " #{IO.iodata_length(payload)}", @newline, payload, @newline]
   def build(:pub, topic, payload, [reply_to: reply]), do: [@pub, " ", topic, " ", reply, " #{IO.iodata_length(payload)}", @newline, payload, @newline]
+
+  def build(:sub, topic, sid, []), do: [@sub, " ", topic, " ", Integer.to_string(sid), @newline]
+  def build(:sub, topic, sid, [queue_group: qg]), do: [@sub, " ", topic, " ", qg, " ", Integer.to_string(sid), @newline]
 
   def build(:unsub, sid, []), do: [@unsub, " #{sid}", @newline]
   def build(:unsub, sid, [max_messages: max]), do: [@unsub, " #{sid}", " #{max}", @newline]

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -12,6 +12,16 @@ defmodule Gnat.CommandTest do
     assert command == "PUB topic INBOX 7\r\npayload\r\n"
   end
 
+  test "formatting a basic sub message" do
+    command = Command.build(:sub, "foobar", 4, []) |> IO.iodata_to_binary
+    assert command == "SUB foobar 4\r\n"
+  end
+
+  test "formatting a sub with a queue group" do
+    command = Command.build(:sub, "foobar", 5, [queue_group: "us"]) |> IO.iodata_to_binary
+    assert command == "SUB foobar us 5\r\n"
+  end
+
   test "formatting a simple unsub message" do
     command = Command.build(:unsub, 12, []) |> IO.iodata_to_binary
     assert command == "UNSUB 12\r\n"


### PR DESCRIPTION
Adds `SUB` formatting in the `Gnat.Command` module including support for `queue_group`. I also added documentation for subscribing and a test to make sure that we fanout messages in some cases and partition messages when queue group is provided.

/cc @newellista @film42 @tallguy-hackett 