### PR TITLE
Partial parse

### DIFF
--- a/test/gnat/parser_test.exs
+++ b/test/gnat/parser_test.exs
@@ -44,4 +44,14 @@ defmodule Gnat.ParserTest do
     assert parser_state.partial == ""
     assert parsed_message == :ping
   end
+
+  test "parsing partial messages" do
+    {parser_state, [parsed_message]} = Parser.new |> Parser.parse("PING\r\nMSG topic 11 4\r\nOH")
+    assert parsed_message == :ping
+    assert parser_state.partial == "MSG topic 11 4\r\nOH"
+    {parser_state, [msg1,msg2]} = Parser.parse(parser_state, "AI\r\nMSG topic 11 3\r\nWAT\r\nMSG topic")
+    assert msg1 == {:msg, "topic", 11, nil, "OHAI"}
+    assert msg2 == {:msg, "topic", 11, nil, "WAT"}
+    assert parser_state.partial == "MSG topic"
+  end
 end


### PR DESCRIPTION
A rough cut at #5

I stole the basic idea here from @newellista who suggested that we only really need to keep the unmatched bytes around for the parser state (no need to have a `state: :waiting` etc). This ends up introducing a few more conditionals which always degrades the readability a bit.

Before I try to refactor I first wanted to get some feedback on whether this looked like a reasonable attempt at parsing.

Benchmarks before and after the change show no significant change in performance (~`81k` parses/sec).

/cc @newellista @tallguy-hackett 