### PR TITLE
Add some test helpers

### DIFF
--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -1,5 +1,5 @@
 defmodule GnatTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Gnat
 
   test "connect to a server" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,13 @@
+ExUnit.configure(exclude: [pending: true])
+
 ExUnit.start()
+
+case :gen_tcp.connect('localhost', 4222, [:binary]) do
+  {:ok, socket} ->
+    :gen_tcp.close(socket)
+  {:error, reason} ->
+    Mix.raise "Cannot connect to gnatsd" <>
+              " (http://localhost:4222):" <>
+              " #{:inet.format_error(reason)}\n" <>
+              "You probably need to start gnatsd."
+end


### PR DESCRIPTION
In `test_helper.exs`, ensure that `gnatsd` is running before starting
the test run.

Also, add tag that will exclude any tests that have the `@tag: pending`
tag.