### PR TITLE
Cleanup subscriptions

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -142,7 +142,7 @@ defmodule Gnat do
   end
   def handle_call({:unsub, sid, opts}, _from, %{receivers: receivers}=state) do
     case Map.has_key?(receivers, sid) do
-      false -> {:reply, {:error, :no_such_subscription}, state}
+      false -> {:reply, :ok, state}
       true ->
         command = Command.build(:unsub, sid, opts)
         :ok = :gen_tcp.send(state.tcp, command)

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -79,12 +79,6 @@ defmodule GnatTest do
     end
   end
 
-  test "invalid unsub command" do
-    {:ok, pid} = Gnat.start_link()
-    assert Gnat.unsub(pid, 15) == {:error, :no_such_subscription}
-    Gnat.stop(pid)
-  end
-
   test "unsubscribing from a topic after a maximum number of messages" do
     topic = "testunsub_maxmsg"
     {:ok, pid} = Gnat.start_link()

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -79,6 +79,12 @@ defmodule GnatTest do
     end
   end
 
+  test "invalid unsub command" do
+    {:ok, pid} = Gnat.start_link()
+    assert Gnat.unsub(pid, 15) == {:error, :no_such_subscription}
+    Gnat.stop(pid)
+  end
+
   test "unsubscribing from a topic after a maximum number of messages" do
     topic = "testunsub_maxmsg"
     {:ok, pid} = Gnat.start_link()


### PR DESCRIPTION
Fixes #32 

The basic idea here is that we track both a `recipient` pid and a `unsub_after` count for each subscription. If we receive an `unsub` with no max messages we cleanup the subscription immediately after sending the UNSUB command to gnats. If we receive an `unsub` with max messages then we tag the subscription with a number of messages to wait for.

Each time we receive a message and deliver it we decrement the amount remaining and we clean it up when the counter reaches 0.

I tested this by opening `observer` and doing 2MM `Gnat.request` calls. My gnat connection process did not grow in memory. I could see that it's state only ever contained 1 subscription entry and it cleaned up all of the rest of them as responses were received.

/cc @newellista @film42 @jjcarstens @tallguy-hackett 