### PR TITLE
Auth required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ before_install:
 
 before_script:
  - ./gnatsd-v0.9.6-linux-amd64/gnatsd -p 4223 --user bob --pass alice &
+
+script:
+  - mix test --include multi_server

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ before_install:
  - wget https://github.com/nats-io/gnatsd/releases/download/v0.9.6/gnatsd-v0.9.6-linux-amd64.zip
  - unzip gnatsd-v0.9.6-linux-amd64.zip
  - ./gnatsd-v0.9.6-linux-amd64/gnatsd &
+
+before_script:
  - ./gnatsd-v0.9.6-linux-amd64/gnatsd -p 4223 --user bob --pass alice &

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ before_install:
  - wget https://github.com/nats-io/gnatsd/releases/download/v0.9.6/gnatsd-v0.9.6-linux-amd64.zip
  - unzip gnatsd-v0.9.6-linux-amd64.zip
  - ./gnatsd-v0.9.6-linux-amd64/gnatsd &
+ - ./gnatsd-v0.9.6-linux-amd64/gnatsd -p 4223 --user bob --pass alice &

--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ As of this commit the most recent numbers from running on my macbook pro are:
 | parse-128 | 90.54 K | 11.04 μs | ±78.18% | 10.00 μs |
 | pub - 128 | 88.03 K | 11.36 μs | ±82.08% | 11.00 μs |
 | subpub-16 | 7.44 K | 134.49 μs | ±47.57% | 122.00 μs |
+
+## Development
+
+To run the tests the typical `mix test` will run all tests that have not been tagged
+to exclude as shown in the `test_helper.exs` file.  There are some tests that require
+another server to be running.  These are marked with `@tag :multi_server` and can be
+included in a test run with the following command `mix test --include multi_server`

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -182,8 +182,7 @@ defmodule Gnat do
   defp perform_handshake(tcp, connection_settings) do
     receive do
       {:tcp, ^tcp, operation} ->
-        {_, [{:info, options}]} = Parser.parse(Parser.new, operation) # |> String.split |> List.first |> String.upcase
-        # :gen_tcp.send(tcp, "CONNECT {\"verbose\": false}\r\n")
+        {_, [{:info, options}]} = Parser.parse(Parser.new, operation)
         connect(tcp, options, connection_settings)
       after 1000 ->
         {:error, "timed out waiting for info"}

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -216,6 +216,7 @@ defmodule Gnat do
   end
   defp process_message(:pong, state) do
     send state.pinger, :pong
+    state
   end
 
   defp update_subscriptions_after_delivering_message(%{receivers: receivers}=state, sid) do

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -95,9 +95,10 @@ defmodule Gnat do
   Ping the NATS server
 
   This correlates to the [PING](http://nats.io/documentation/internals/nats-protocol/#PINGPONG) command in the NATS protocol.
+  If the NATS server responds with a PONG message this function will return `:ok`
   ```
   {:ok, gnat} = Gnat.start_link()
-  {:pong} = Gnat.ping(gnat)
+  :ok = Gnat.ping(gnat)
   ```
   """
   def ping(pid) do

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -5,7 +5,6 @@
 defmodule Gnat do
   use GenServer
   require Logger
-  require Poison
   alias Gnat.{Command, Parser}
 
   @default_connection_settings %{

--- a/lib/gnat/parser.ex
+++ b/lib/gnat/parser.ex
@@ -1,5 +1,6 @@
 defmodule Gnat.Parser do
   require Logger
+  require Poison
   # states: waiting, reading_message
   defstruct [
     partial: "",
@@ -39,6 +40,7 @@ defmodule Gnat.Parser do
   end
 
   defp parse_command("PING", _, body), do: {:ping, body}
+  defp parse_command("PONG", _, body), do: {:pong, body}
   defp parse_command("MSG", [topic, sidstr, sizestr], body), do: parse_command("MSG", [topic, sidstr, nil, sizestr], body)
   defp parse_command("MSG", [topic, sidstr, reply_to, sizestr], body) do
     sid = String.to_integer(sidstr)
@@ -49,5 +51,8 @@ defmodule Gnat.Parser do
     else
       :partial_message
     end
+  end
+  defp parse_command("INFO", options, body) do
+    {{:info, Poison.Parser.parse!(options, keys: :atoms)}, body}
   end
 end

--- a/lib/gnat/parser.ex
+++ b/lib/gnat/parser.ex
@@ -1,6 +1,5 @@
 defmodule Gnat.Parser do
   require Logger
-  require Poison
   # states: waiting, reading_message
   defstruct [
     partial: "",

--- a/mix.exs
+++ b/mix.exs
@@ -18,6 +18,7 @@ defmodule Gnat.Mixfile do
     [
       {:benchee, "~> 0.6.0", only: :dev},
       {:ex_doc, "~> 0.15", only: :dev},
+      {:poison, "~> 3.0"},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{"benchee": {:hex, :benchee, "0.6.0", "c2565506c621ee010e71d05f555e39a1b937e00810e284bc85463a4d4efc4b00", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, optional: false]}]},
   "deep_merge": {:hex, :deep_merge, "0.1.1", "c27866a7524a337b6a039eeb8dd4f17d458fd40fbbcb8c54661b71a22fffe846", [:mix], []},
   "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]}}
+  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []}}

--- a/test/gnat/parser_test.exs
+++ b/test/gnat/parser_test.exs
@@ -54,4 +54,19 @@ defmodule Gnat.ParserTest do
     assert msg2 == {:msg, "topic", 11, nil, "WAT"}
     assert parser_state.partial == "MSG topic"
   end
+
+  test "parsing INFO message" do
+    {parser_state, [parsed_message]} = Parser.new |> Parser.parse("INFO {\"server_id\":\"1ec445b504f4edfb4cf7927c707dd717\",\"version\":\"0.6.6\",\"go\":\"go1.4.2\",\"host\":\"0.0.0.0\",\"port\":4222,\"auth_required\":false,\"ssl_required\":false,\"max_payload\":1048576}\r\n")
+    assert parser_state.partial == ""
+    assert parsed_message == {:info, %{
+                                        server_id: "1ec445b504f4edfb4cf7927c707dd717",
+                                        version: "0.6.6",
+                                        go: "go1.4.2",
+                                        host: "0.0.0.0",
+                                        port: 4222,
+                                        auth_required: false,
+                                        ssl_required: false,
+                                        max_payload: 1048576
+                                      }}
+  end
 end

--- a/test/gnat/parser_test.exs
+++ b/test/gnat/parser_test.exs
@@ -69,4 +69,10 @@ defmodule Gnat.ParserTest do
                                         max_payload: 1048576
                                       }}
   end
+
+  test "parsing PONG message" do
+    {parser_state, [parsed_message]} = Parser.new |> Parser.parse("PONG\r\n")
+    assert parser_state.partial == ""
+    assert parsed_message == :pong
+  end
 end

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -2,12 +2,31 @@ defmodule GnatTest do
   use ExUnit.Case, async: true
   doctest Gnat
 
+  setup context do
+    if context[:multi_server] do
+      case :gen_tcp.connect('localhost', 4223, [:binary]) do
+        {:ok, socket} ->
+          :gen_tcp.close(socket)
+        {:error, reason} ->
+          Mix.raise "Cannot connect to gnatsd" <>
+                    " (http://localhost:4223):" <>
+                    " #{:inet.format_error(reason)}\n" <>
+                    "You probably need to start a gnatsd " <>
+                    "server that requires authentication with " <>
+                    "the following command `gnatsd -p 4223 " <>
+                    "--user bob --pass alice`."
+      end
+    end
+    :ok
+  end
+
   test "connect to a server" do
     {:ok, pid} = Gnat.start_link()
     assert Process.alive?(pid)
     :ok = Gnat.stop(pid)
   end
 
+  @tag :multi_server
   test "connect to a server with authentication" do
     connection_settings = %{
       host: 'localhost',

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -8,6 +8,20 @@ defmodule GnatTest do
     :ok = Gnat.stop(pid)
   end
 
+  test "connect to a server with authentication" do
+    connection_settings = %{
+      host: 'localhost',
+      port: 4223,
+      tcp_opts: [:binary],
+      username: "bob",
+      password: "alice"
+    }
+    {:ok, pid} = Gnat.start_link(connection_settings)
+    assert Process.alive?(pid)
+    :ok = Gnat.ping(pid)
+    :ok = Gnat.stop(pid)
+  end
+
   test "subscribe to topic and receive a message" do
     {:ok, pid} = Gnat.start_link()
     {:ok, _ref} = Gnat.sub(pid, self(), "test")

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,3 +11,16 @@ case :gen_tcp.connect('localhost', 4222, [:binary]) do
               " #{:inet.format_error(reason)}\n" <>
               "You probably need to start gnatsd."
 end
+
+case :gen_tcp.connect('localhost', 4223, [:binary]) do
+  {:ok, socket} ->
+    :gen_tcp.close(socket)
+  {:error, reason} ->
+    Mix.raise "Cannot connect to gnatsd" <>
+              " (http://localhost:4223):" <>
+              " #{:inet.format_error(reason)}\n" <>
+              "You probably need to start a gnatsd " <>
+              "server that requires authentication with " <>
+              "the following command `gnatsd -p 4223 " <>
+              "--user bob --pass alice`."
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
-ExUnit.configure(exclude: [pending: true])
+ExUnit.configure(exclude: [:pending, :multi_server])
 
 ExUnit.start()
 
@@ -10,17 +10,4 @@ case :gen_tcp.connect('localhost', 4222, [:binary]) do
               " (http://localhost:4222):" <>
               " #{:inet.format_error(reason)}\n" <>
               "You probably need to start gnatsd."
-end
-
-case :gen_tcp.connect('localhost', 4223, [:binary]) do
-  {:ok, socket} ->
-    :gen_tcp.close(socket)
-  {:error, reason} ->
-    Mix.raise "Cannot connect to gnatsd" <>
-              " (http://localhost:4223):" <>
-              " #{:inet.format_error(reason)}\n" <>
-              "You probably need to start a gnatsd " <>
-              "server that requires authentication with " <>
-              "the following command `gnatsd -p 4223 " <>
-              "--user bob --pass alice`."
 end


### PR DESCRIPTION
This fixes #27 

I added functionality to pass connection information into the parser to generate the `CONNECT` command.  This may not be the best way to do it so I'm very open to suggestions.  I also added a `Gnat.ping` function that sends a `PING` command to the server to help verify an authenticated connection without a need for a subscription request.

There's also no error handling if the client tries to use a connection without authenticating.