### PR TITLE
Client cert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
 before_script:
  - ./gnatsd-v0.9.6-linux-amd64/gnatsd -p 4223 --user bob --pass alice &
  - ./gnatsd-v0.9.6-linux-amd64/gnatsd -p 4224 --tls --tlscert test/fixtures/server.pem --tlskey test/fixtures/key.pem &
+ - ./gnatsd-v0.9.6-linux-amd64/gnatsd -p 4225 --tls --tlscert test/fixtures/server.pem --tlskey test/fixtures/key.pem --tlscacert test/fixtures/ca.pem --tlsverify &
 
 script:
   - mix test --include multi_server

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -16,6 +16,21 @@ defmodule Gnat do
   }
 
   def start_link, do: start_link(%{})
+
+  @doc """
+  Starts a connection to a nats broker
+
+  ```
+  {:ok, gnat} = Gnat.start_link(%{host: '127.0.0.1', port: 4222})
+  # if the server requires TLS you can start a connection with:
+  {:ok, gnat} = Gnat.start_link(%{host: '127.0.0.1', port: 4222, tls: true})
+  # if the server requires TLS and a client certificate you can start a connection with:
+  {:ok, gnat} = Gnat.start_link(%{tls: true, ssl_opts: [certfile: "client-cert.pem", keyfile: "client-key.pem"]})
+  ```
+
+  You can also pass arbitrary SSL or TCP options in the `tcp_opts` and `ssl_opts` keys.
+  If you pass custom TCP options please include `:binary`. Gnat uses binary matching to parse messages.
+  """
   def start_link(connection_settings) do
     GenServer.start_link(__MODULE__, connection_settings)
   end

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -36,6 +36,21 @@ defmodule GnatTest do
     assert Gnat.stop(gnat) == :ok
   end
 
+  @tag :multi_server
+  test "connect to a server which requires TLS with a client certificate" do
+    connection_settings = %{
+      port: 4225,
+      tls: true,
+      ssl_opts: [
+        certfile: "test/fixtures/client-cert.pem",
+        keyfile: "test/fixtures/client-key.pem",
+      ],
+    }
+    {:ok, gnat} = Gnat.start_link(connection_settings)
+    assert Gnat.ping(gnat) == :ok
+    assert Gnat.stop(gnat) == :ok
+  end
+
   test "subscribe to topic and receive a message" do
     {:ok, pid} = Gnat.start_link()
     {:ok, _ref} = Gnat.sub(pid, self(), "test")

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -57,6 +57,21 @@ defmodule CheckForExpectedNatsServers do
                   "--tls --tlscert test/fixtures/server.pem " <>
                   "--tlskey test/fixtures/key.pem`."
     end
+
+    case :gen_tcp.connect('localhost', 4225, [:binary]) do
+      {:ok, socket} ->
+        :gen_tcp.close(socket)
+      {:error, reason} ->
+        Mix.raise "Cannot connect to gnatsd" <>
+                  " (tcp://localhost:4225):" <>
+                  " #{:inet.format_error(reason)}\n" <>
+                  "You probably need to start a gnatsd " <>
+                  "server that requires tls with " <>
+                  "a command like `gnatsd -p 4225 --tls " <>
+                  "--tlscert test/fixtures/server.pem " <>
+                  "--tlskey test/fixtures/key.pem " <>
+                  "--tlscacert test/fixtures/ca.pem --tlsverify"
+    end
   end
   def check_for_tag(_), do: :ok
 end


### PR DESCRIPTION
💥 💥 💥 💥 💥 💥 

I wrote a failing test assuming that I would have to fix it with implementation code, but since we already allow passing in of the `ssl_opts`, this turned out to just be a matter of passing in connection options.

I went ahead and documented some of the connection options and this documentation looks like this when rendered:
<img width="872" alt="screen shot 2017-04-13 at 9 19 13 pm" src="https://cloud.githubusercontent.com/assets/80008/25032138/032d2a1c-208f-11e7-91c1-9396bba40ff5.png">

/cc @film42 @newellista @jjcarstens @quixoten @tallguy-hackett 