### PR TITLE
Moar docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@
 A [nats.io](https://nats.io/) client for elixir.
 The goals of the project are resiliency, performance, and ease of use.
 
-## Installation
-
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `gnat` to your list of dependencies in `mix.exs`:
+## Usage
 
 ```elixir
-def deps do
-  [{:gnat, "~> 0.1.0"}]
+{:ok, gnat} = Gnat.start_link(%{host: '127.0.0.1', port: 4222})
+# Or if the server requires TLS you can start a connection with:
+# {:ok, gnat} = Gnat.start_link(%{host: '127.0.0.1', port: 4222, tls: true})
+
+{:ok, subscription} = Gnat.sub(gnat, self(), "pawnee.*")
+:ok = Gnat.pub(gnat, "pawnee.news", "Leslie Knope recalled from city council (Jammed)")
+receive do
+  {:msg, %{body: body, topic: "pawnee.news", reply_to: nil}} ->
+    IO.puts(body)
 end
 ```
-
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/gnat](https://hexdocs.pm/gnat).
 
 ## Benchmarks
 
@@ -30,9 +30,17 @@ As of this commit the most recent numbers from running on my macbook pro are:
 
 |   | ips | average | deviation | median |
 | - | --- | ------- | --------- | ------ |
-| parse-128 | 90.54 K | 11.04 μs | ±78.18% | 10.00 μs |
-| pub - 128 | 88.03 K | 11.36 μs | ±82.08% | 11.00 μs |
-| subpub-16 | 7.44 K | 134.49 μs | ±47.57% | 122.00 μs |
+| parse-128 | 81.86 K | 12.22 μs | ±177.12% | 11.00 μs |
+| pub - 128 | 146.22 K | 6.84 μs | ±450.03% | 6.00 μs |
+| sub-unsub-pub16 | 9.06 K | 110.37 μs | ±68.61% | 102.00 μs |
+| req-reply-4 | 5.67 K | 176.45 μs | ±19.81% | 165.00 μs |
+
+These benchmarks all show single-actor performance with a locally running gnats server.
+Running 32 client actors on an 8-core ubuntu server sending requests to another 8-core ubuntu server running 2 gnat subscriber actors we achieved:
+* 19,920 requests/sec
+* 90th % latency of 2.2ms
+
+[see details in the performance issue](https://github.com/mmmries/gnat/issues/28)
 
 ## Development
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,12 +2,19 @@ defmodule Gnat.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :gnat,
-     version: "0.1.0",
-     elixir: "~> 1.4",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps()]
+    [
+      app: :gnat,
+      version: "0.1.0",
+      elixir: "~> 1.4",
+      build_embedded: Mix.env == :prod,
+      start_permanent: Mix.env == :prod,
+      deps: deps(),
+      docs: [
+        main: "readme",
+        logo: "gnat.png",
+        extras: ["README.md"],
+      ]
+    ]
   end
 
   def application do


### PR DESCRIPTION
Just updates some docs. Now when we publish to hex our documentation homepage will be the README.

![screen shot 2017-04-14 at 6 39 19 am](https://cloud.githubusercontent.com/assets/80008/25043841/3101a822-20e0-11e7-8a53-4d7afe17e0fc.png)

I think after this we should go ahead and publish a `0.1.0` version to hex.

/cc @newellista @film42 @tallguy-hackett @quixoten @jjcarstens 

