### PR TITLE
Handle errors

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -234,6 +234,13 @@ defmodule Gnat do
     send state.pinger, :pong
     state
   end
+  defp process_message({:error, message}, state) do
+    :error_logger.error_report([
+      type: :gnat_error_from_broker,
+      message: message,
+    ])
+    state
+  end
 
   defp update_subscriptions_after_delivering_message(%{receivers: receivers}=state, sid) do
     receivers = case get_in(receivers, [sid, :unsub_after]) do

--- a/lib/gnat/parser.ex
+++ b/lib/gnat/parser.ex
@@ -54,4 +54,7 @@ defmodule Gnat.Parser do
   defp parse_command("INFO", options, body) do
     {{:info, Poison.Parser.parse!(options, keys: :atoms)}, body}
   end
+  defp parse_command("-ERR", options, body) do
+    {{:error, Enum.join(options, " ")},body}
+  end
 end

--- a/test/gnat/parser_test.exs
+++ b/test/gnat/parser_test.exs
@@ -75,4 +75,15 @@ defmodule Gnat.ParserTest do
     assert parser_state.partial == ""
     assert parsed_message == :pong
   end
+
+  test "parsing -ERR message" do
+    {parser_state, [parsed_message]} = Parser.new |> Parser.parse("-ERR 'Unknown Protocol Operation'\r\n")
+    assert parser_state.partial == ""
+    assert parsed_message == {:error, "'Unknown Protocol Operation'"}
+  end
+
+  test "parsing -ERR messages in the middle of other traffic" do
+    assert {parser, [:ping]} = Parser.new |> Parser.parse("PING\r\n-ERR 'Unknown Pro")
+    assert {_, [{:error, "'Unknown Protocol Operation'"}]} = parser |> Parser.parse("tocol Operation'\r\nMSG")
+  end
 end

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -156,4 +156,14 @@ defmodule GnatTest do
       end
     end)
   end
+
+  test "recording errors from the broker" do
+    import ExUnit.CaptureLog
+    {:ok, gnat} = Gnat.start_link()
+    assert capture_log(fn ->
+      Process.flag(:trap_exit, true)
+      Gnat.sub(gnat, self(), "invalid\r\nsubject")
+      Process.sleep(20) # errors are reported asynchronously so we need to wait a moment
+    end) =~ "Parser Error"
+  end
 end


### PR DESCRIPTION
Basic support for `-ERR` messages coming from the broker (see #41)

This PR adds support for parsing the messages from the broker and forwarding them to the [error_logger](http://erlang.org/doc/man/error_logger.html) which is the standard OTP mechanism for error reports, crash reports etc. It is a pluggable system so I'm thinking it will be possible for people to hook up honeybadger or other error monitoring solutions to report these errors.

/cc @film42 @newellista @tallguy-hackett @jjcarstens 