### PR TITLE
Support configurable connection timeout

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -11,7 +11,7 @@ defmodule Gnat do
     host: 'localhost',
     port: 4222,
     tcp_opts: [:binary],
-    timeout: 3_000,
+    connection_timeout: 3_000,
     ssl_opts: [],
     tls: false,
   }

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -11,6 +11,7 @@ defmodule Gnat do
     host: 'localhost',
     port: 4222,
     tcp_opts: [:binary],
+    timeout: 3_000,
     ssl_opts: [],
     tls: false,
   }
@@ -133,7 +134,7 @@ defmodule Gnat do
         parser = Parser.new
         {:ok, %{socket: socket, connection_settings: connection_settings, next_sid: 1, receivers: %{}, parser: parser}}
       {:error, reason} ->
-        {:error, reason}
+        {:stop, reason}
     end
   end
 

--- a/lib/gnat/handshake.ex
+++ b/lib/gnat/handshake.ex
@@ -5,7 +5,7 @@ defmodule Gnat.Handshake do
   This module provides a single function which handles all of the variations of establishing a connection to a gnatsd server and just returns {:ok, socket} or {:error, reason}
   """
   def connect(settings) do
-    case :gen_tcp.connect(settings.host, settings.port, settings.tcp_opts, settings.timeout) do
+    case :gen_tcp.connect(settings.host, settings.port, settings.tcp_opts, settings.connection_timeout) do
       {:ok, tcp} -> perform_handshake(tcp, settings)
       result -> result
     end

--- a/lib/gnat/handshake.ex
+++ b/lib/gnat/handshake.ex
@@ -5,8 +5,10 @@ defmodule Gnat.Handshake do
   This module provides a single function which handles all of the variations of establishing a connection to a gnatsd server and just returns {:ok, socket} or {:error, reason}
   """
   def connect(settings) do
-    {:ok, tcp} = :gen_tcp.connect(settings.host, settings.port, settings.tcp_opts)
-    perform_handshake(tcp, settings)
+    case result = :gen_tcp.connect(settings.host, settings.port, settings.tcp_opts, settings.timeout) do
+      {:ok, tcp} -> perform_handshake(tcp, settings)
+      _ -> result
+    end
   end
 
   defp perform_handshake(tcp, connection_settings) do

--- a/lib/gnat/handshake.ex
+++ b/lib/gnat/handshake.ex
@@ -5,9 +5,9 @@ defmodule Gnat.Handshake do
   This module provides a single function which handles all of the variations of establishing a connection to a gnatsd server and just returns {:ok, socket} or {:error, reason}
   """
   def connect(settings) do
-    case result = :gen_tcp.connect(settings.host, settings.port, settings.tcp_opts, settings.timeout) do
+    case :gen_tcp.connect(settings.host, settings.port, settings.tcp_opts, settings.timeout) do
       {:ok, tcp} -> perform_handshake(tcp, settings)
-      _ -> result
+      result -> result
     end
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
-%{"benchee": {:hex, :benchee, "0.6.0", "c2565506c621ee010e71d05f555e39a1b937e00810e284bc85463a4d4efc4b00", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, optional: false]}]},
-  "deep_merge": {:hex, :deep_merge, "0.1.1", "c27866a7524a337b6a039eeb8dd4f17d458fd40fbbcb8c54661b71a22fffe846", [:mix], []},
-  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []}}
+%{"benchee": {:hex, :benchee, "0.6.0", "c2565506c621ee010e71d05f555e39a1b937e00810e284bc85463a4d4efc4b00", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm"},
+  "deep_merge": {:hex, :deep_merge, "0.1.1", "c27866a7524a337b6a039eeb8dd4f17d458fd40fbbcb8c54661b71a22fffe846", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"}}

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -169,7 +169,7 @@ defmodule GnatTest do
 
   test "connection timeout" do
     start = System.monotonic_time(:millisecond)
-    connection_settings = %{ host: '169.33.33.33', timeout: 200 }
+    connection_settings = %{ host: '169.33.33.33', connection_timeout: 200 }
     {:stop, :timeout} = Gnat.init(connection_settings)
     assert_in_delta System.monotonic_time(:millisecond) - start, 200, 10
   end

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -166,4 +166,11 @@ defmodule GnatTest do
       Process.sleep(20) # errors are reported asynchronously so we need to wait a moment
     end) =~ "Parser Error"
   end
+
+  test "connection timeout" do
+    start = System.monotonic_time(:millisecond)
+    connection_settings = %{ host: '169.33.33.33', timeout: 200 }
+    {:stop, :timeout} = Gnat.init(connection_settings)
+    assert_in_delta System.monotonic_time(:millisecond) - start, 200, 10
+  end
 end


### PR DESCRIPTION
This adds support for a configurable connection timeout that defaults to
3 seconds. I also changed the return value in the init function under
error conditions to `{:stop, reason}` from `{:error, reason}`. I think
this is correct because `{:error, reason}` generated:

```
** (EXIT from #PID<0.208.0>) bad return value: {:error, :timeout}
```

I could also not find support for `{:error, _}` in the docs:
https://hexdocs.pm/elixir/GenServer.html#c:init/1

This was tricky to test because calling `Gnat.start_link` killed the
test immediately. Hopefully calling `Gnat.init` instead is a viable way
to test the behavior.

---

@mmmries @film42 @newellista @tallguy-hackett @jjcarstens