### PR TITLE
Ensure receiver exists before delivering message

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -249,8 +249,11 @@ defmodule Gnat do
   end
 
   defp process_message({:msg, topic, sid, reply_to, body}, state) do
-    send state.receivers[sid].recipient, {:msg, %{topic: topic, body: body, reply_to: reply_to}}
-    update_subscriptions_after_delivering_message(state, sid)
+    unless is_nil(state.receivers[sid]) do
+      send state.receivers[sid].recipient, {:msg, %{topic: topic, body: body, reply_to: reply_to}}
+      update_subscriptions_after_delivering_message(state, sid)
+    end
+    state
   end
   defp process_message(:ping, state) do
     socket_write(state, "PONG\r\n")

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -252,8 +252,9 @@ defmodule Gnat do
     unless is_nil(state.receivers[sid]) do
       send state.receivers[sid].recipient, {:msg, %{topic: topic, body: body, reply_to: reply_to}}
       update_subscriptions_after_delivering_message(state, sid)
+    else
+      state
     end
-    state
   end
   defp process_message(:ping, state) do
     socket_write(state, "PONG\r\n")


### PR DESCRIPTION
Add checking existence of receiver because calling publish & unsubscribe at the same time might cause receiving message for deleted receiver.
