### PR TITLE
Supervised consumers

### DIFF
--- a/lib/gnat/connection_supervisor.ex
+++ b/lib/gnat/connection_supervisor.ex
@@ -11,7 +11,7 @@ defmodule Gnat.ConnectionSupervisor do
   ```
   gnat_supervisor_settings = %{
     name: :gnat, # (required) the registered named you want to give the Gnat connection
-    backoff_period: 4_000, # number of milliseconds to wait between consecurity reconnect attempts (default: 2_000)
+    backoff_period: 4_000, # number of milliseconds to wait between consecutive reconnect attempts (default: 2_000)
     connection_settings: [
       %{host: '10.0.0.100', port: 4222},
       %{host: '10.0.0.101', port: 4222},
@@ -19,7 +19,7 @@ defmodule Gnat.ConnectionSupervisor do
   }
   ```
 
-  The connection settings can specify all of the same values that you pass to `Gnat.start_start_link/1`. Each time a connection is attempted we will use one of the provided connection settings to open the connection. This is a simplistic way of load balancing your connections across a cluster of nats nodes and allowing failove to other nodes in the cluster if one goes down.
+  The connection settings can specify all of the same values that you pass to `Gnat.start_link/1`. Each time a connection is attempted we will use one of the provided connection settings to open the connection. This is a simplistic way of load balancing your connections across a cluster of nats nodes and allowing failover to other nodes in the cluster if one goes down.
 
   To use this in your supervision tree add an entry like this:
 

--- a/lib/gnat/consumer_supervisor.ex
+++ b/lib/gnat/consumer_supervisor.ex
@@ -1,0 +1,58 @@
+defmodule Gnat.ConsumerSupervisor do
+  use GenServer
+  require Logger
+
+  def start_link(settings, options) do
+    GenServer.start_link(__MODULE__, settings, options)
+  end
+
+  def init(settings) do
+    Process.flag(:trap_exit, true)
+    {:ok, task_supervisor_pid} = Task.Supervisor.start_link()
+    connection_name = Map.get(settings, :connection_name)
+    subscription_topics = Map.get(settings, :subscription_topics)
+    consuming_function = Map.get(settings, :consuming_function)
+    send self(), :connect
+    state = %{
+      connection_name: connection_name,
+      connection_pid: nil,
+      consuming_function: consuming_function,
+      status: :disconnected,
+      subscription_topics: subscription_topics,
+      subscriptions: [],
+      task_supervisor_pid: task_supervisor_pid,
+    }
+    {:ok, state}
+  end
+
+  def handle_info(:connect, %{connection_name: name}=state) do
+    case Process.whereis(name) do
+      nil ->
+        Process.send_after(self(), :connect, 2_000)
+        {:noreply, state}
+      connection_pid ->
+        _ref = Process.monitor(connection_pid)
+        subscriptions = Enum.map(state.subscription_topics, fn(topic_and_queue_group) ->
+          topic = Map.fetch!(topic_and_queue_group, :topic)
+          queue_group = Map.get(topic_and_queue_group, :queue_group)
+          {:ok, subscription} = Gnat.sub(connection_pid, self(), topic, queue_group: queue_group)
+          subscription
+        end)
+        {:noreply, %{state | status: :connected, connection_pid: connection_pid, subscriptions: subscriptions}}
+    end
+  end
+
+  def handle_info({:DOWN, _ref, :process, connection_pid, _reason}, %{connnection_pid: connection_pid}=state) do
+    Process.send_after(self(), :connect, 2_000)
+    {:noreply, %{state | status: :disconnected, connection_pid: nil, subscriptions: []}}
+  end
+
+  def handle_info({:msg, gnat_message}, %{consuming_function: {mod, fun}}=state) do
+    Task.Supervisor.async_nolink(state.task_supervisor_pid, mod, fun, [gnat_message])
+    {:noreply, state}
+  end
+
+  def terminate(_reason, _state) do
+    # TODO unsub, then wait for the task supervisor to be empty
+  end
+end


### PR DESCRIPTION
This is a first cut at having supervised consumers. This feature can be used to support things like RPC servers where a client application wants to have long-lived subscriptions that last across re-connect attempts. It works by adding an entry to your supervision tree like:

```elixir
consumer_settings = %{
  connection_name: :rpc_gnat,
  consuming_function: {Dispatch.RpcServer, :handle_request},
  subscription_topics: [
    %{topic: "rpc.atlas.dispatch.shard_service.search", queue_group: "rpc.atlas.dispatch.shard_service.search"},
    %{topic: "rpc.atlas.dispatch.user_shard_service.search", queue_group: "rpc.atlas.dispatch.user_shard_service.search"},
  ],
}

children = [worker(Gnat.ConsumerSupervisor, [settings, [name: :rpc_consumer]], shutdown: 30_000)]
supervise(children, strategy: :one_for_one)
```

This consumer supervisor will check for the named connection, and if it finds the connection available it will subscribe to the given topics and monitor that connection. It automatically retries in the case that the connection dies or is unavailable. It will then call the module and function you specify whenever a message arrives for one of those subscriptions.

In a future cut I will add graceful shutdown that unsubscribes itself from the topics and waits for all of the outstanding tasks to complete before finishing its shutdown. How long to wait can be configured in the supervision tree via the `:shutdown` option which will give the `ConsumerSupervisor` a configurable number of milliseconds to finish its own shutdown before it is sent a hard kill signal and forced to shutdown.

I also need to add a moduledoc and perhaps a few sanity tests in a followup PR

/cc @newellista @film42 @abrandoned