### PR TITLE
Supervised consumers followup

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -252,6 +252,7 @@ defmodule Gnat do
       send state.receivers[sid].recipient, {:msg, %{topic: topic, body: body, reply_to: reply_to}}
       update_subscriptions_after_delivering_message(state, sid)
     else
+      Logger.error "#{__MODULE__} got message for sid #{sid}, but that is no longer registered"
       state
     end
   end

--- a/lib/gnat/connection_supervisor.ex
+++ b/lib/gnat/connection_supervisor.ex
@@ -11,7 +11,7 @@ defmodule Gnat.ConnectionSupervisor do
   ```
   gnat_supervisor_settings = %{
     name: :gnat, # (required) the registered named you want to give the Gnat connection
-    backoff_period: 4_000, # number of milliseconds to wait between consecurity reconnect attempts (default: 2_000)
+    backoff_period: 4_000, # number of milliseconds to wait between consecutive reconnect attempts (default: 2_000)
     connection_settings: [
       %{host: '10.0.0.100', port: 4222},
       %{host: '10.0.0.101', port: 4222},
@@ -19,7 +19,7 @@ defmodule Gnat.ConnectionSupervisor do
   }
   ```
 
-  The connection settings can specify all of the same values that you pass to `Gnat.start_start_link/1`. Each time a connection is attempted we will use one of the provided connection settings to open the connection. This is a simplistic way of load balancing your connections across a cluster of nats nodes and allowing failove to other nodes in the cluster if one goes down.
+  The connection settings can specify all of the same values that you pass to `Gnat.start_link/1`. Each time a connection is attempted we will use one of the provided connection settings to open the connection. This is a simplistic way of load balancing your connections across a cluster of nats nodes and allowing failover to other nodes in the cluster if one goes down.
 
   To use this in your supervision tree add an entry like this:
 

--- a/lib/gnat/connection_supervisor.ex
+++ b/lib/gnat/connection_supervisor.ex
@@ -25,10 +25,10 @@ defmodule Gnat.ConnectionSupervisor do
 
   ```
   import Supervisor.Spec
-  worker(Gnat.ConnectionSupervisor, [gnat_supervisor_settings])
+  worker(Gnat.ConnectionSupervisor, [gnat_supervisor_settings, [name: :my_connection_supervisor]])
   ```
 
-  Now in the rest of your code you can call things like:
+  The second argument is used as GenServer options so you can give the supervisor a registered name as well if you like. Now in the rest of your code you can call things like:
 
   ```
   :ok = Gnat.pub(:gnat, "subject", "message")
@@ -37,8 +37,8 @@ defmodule Gnat.ConnectionSupervisor do
   And it will use your supervised connection. If the connection is down when you call that function (or dies during that function) it will raise an error.
   """
 
-  def start_link(options) do
-    GenServer.start_link(__MODULE__, options, name: __MODULE__)
+  def start_link(settings, options \\ []) do
+    GenServer.start_link(__MODULE__, settings, options)
   end
 
   def init(options) do

--- a/lib/gnat/consumer_supervisor.ex
+++ b/lib/gnat/consumer_supervisor.ex
@@ -1,0 +1,58 @@
+defmodule Gnat.ConsumerSupervisor do
+  use GenServer
+  require Logger
+
+  def start_link(settings, options) do
+    GenServer.start_link(__MODULE__, settings, options)
+  end
+
+  def init(settings) do
+    Process.flag(:trap_exit, true)
+    {:ok, task_supervisor_pid} = Task.Supervisor.start_link()
+    connection_name = Map.get(settings, :connection_name)
+    subscription_topics = Map.get(settings, :subscription_topics)
+    consuming_function = Map.get(settings, :consuming_function)
+    send self(), :connect
+    state = %{
+      connection_name: connection_name,
+      connection_pid: nil,
+      consuming_function: consuming_function,
+      status: :disconnected,
+      subscription_topics: subscription_topics,
+      subscriptions: [],
+      task_supervisor_pid: task_supervisor_pid,
+    }
+    {:ok, state}
+  end
+
+  def handle_info(:connect, %{connection_name: name}=state) do
+    case Process.whereis(name) do
+      nil ->
+        Process.send_after(self(), :connect, 2_000)
+        {:noreply, state}
+      connection_pid ->
+        _ref = Process.monitor(connection_pid)
+        subscriptions = Enum.map(state.subscription_topics, fn(topic_and_queue_group) ->
+          topic = Map.fetch!(topic_and_queue_group, :topic)
+          queue_group = Map.get(topic_and_queue_group, :queue_group)
+          {:ok, subscription} = Gnat.sub(connection_pid, self(), topic, queue_group: queue_group)
+          subscription
+        end)
+        {:noreply, %{state | status: :connected, connection_pid: connection_pid, subscriptions: subscriptions}}
+    end
+  end
+
+  def handle_info({:DOWN, _ref, :process, connection_pid, _reason}, %{connnection_pid: connection_pid}=state) do
+    Process.send_after(self(), :connect, 2_000)
+    {:noreply, %{state | status: :disconnected, connection_pid: nil, subscriptions: []}}
+  end
+
+  def handle_info({:msg, gnat_message}, %{consuming_function: {mod, fun}}=state) do
+    Task.Supervisor.async_nolink(state.task_supervisor_pid, mod, fun, [gnat_message])
+    {:noreply, state}
+  end
+
+  def terminate(_reason, _state) do
+    # TODO unsub, then wait for the task supervisor to be empty
+  end
+end

--- a/lib/gnat/consumer_supervisor.ex
+++ b/lib/gnat/consumer_supervisor.ex
@@ -2,7 +2,31 @@ defmodule Gnat.ConsumerSupervisor do
   use GenServer
   require Logger
 
-  def start_link(settings, options) do
+  @moduledoc """
+  A process that can supervise consumers for you
+
+  If you want to subscribe to a few topics and have that subscription last across restarts for you, then this worker can be of help. It also spawns a supervised `Task` for each message it receives. This way errors in message processing don't crash the consumers, but you will still get SASL reports that you can send to services like honeybadger.
+
+  To use this just add an entry to your supervision tree like this:
+
+  ```
+  consumer_supervisor_settings = %{
+    connection_name: :name_of_supervised_connection,
+    consuming_function: {MyApp.RpcServer, :handle_request},
+    subscription_topics: [
+      %{topic: "rpc.MyApp.search", queue_group: "rpc.MyApp.search"},
+      %{topic: "rpc.MyApp.create", queue_group: "rpc.MyApp.create"},
+    ],
+  }
+  worker(Gnat.ConsumerSupervisor, [consumer_supervisor_settings, [name: :rpc_consumer]], shutdown: 30_000)
+  ```
+
+  The second argument is a keyword list that gets used as the GenServer options so you can pass a name that you want to register for the consumer process if you like. The `consuming_function` specific which module and function to call when messages arrive. The function will be called with a single argument which is a gnat message just like you get when you call `Gnat.sub` directly.
+
+  You can have a single consumer that subscribes to multiple topics or multiple consumers that subscribe to different topics and call different consuming functions. It is recommended that your `ConsumerSupervisor`s are present later in your supervision tree than your `ConnectionSupervisor`. That way during a shutdown the `ConsumerSupervisor` can attempt a graceful shutdown of the consumer before shutting down the connection.
+  """
+
+  def start_link(settings, options \\ []) do
     GenServer.start_link(__MODULE__, settings, options)
   end
 


### PR DESCRIPTION
This is the followup to #59 

[Diff link to view diff since #59](https://github.com/mmmries/gnat/compare/supervised_consumers...supervised_consumers_followup)

It adds some documentation and a graceful shutdown mechanism that attempts to unsubscribe and allow some time for messages to finish arriving and processing. The timeout is controlled via the supervision tree (ie `worker(Gnat.ConsumerSupervisor, [settings], shutdown: 30_000)` gives a 30second grace period for the consumer to finish processing before it will be forcibly killed.

I tested it locally with a bunch of extra logging to make sure that all messages were being processed.

/cc @abrandoned @newellista @film42 @quixoten 