### PR TITLE
accept multiple pub commands and send them in a single TCP command

### DIFF
--- a/bench.exs
+++ b/bench.exs
@@ -28,19 +28,19 @@ msg16="74c93e71c5aa03ad"
 
 tcp_packet = "MSG topic 1 128\r\n#{msg128}\r\n"
 Benchee.run(%{
-  "parse-128" => fn -> {_parser, [_msg]} = Gnat.Parser.new() |> Gnat.Parser.parse(tcp_packet) end,
+ "parse-128" => fn -> {_parser, [_msg]} = Gnat.Parser.new() |> Gnat.Parser.parse(tcp_packet) end,
   "pub - 128" => fn -> :ok = Gnat.pub(pid, "pub128", msg128) end,
-  "sub-unsub-pub-16" => fn ->
-    rand = :crypto.strong_rand_bytes(8) |> Base.encode64
-    {:ok, subscription} = Gnat.sub(pid, self(), rand)
-    :ok = Gnat.unsub(pid, subscription, max_messages: 1)
-    :ok = Gnat.pub(pid, rand, msg16)
-    receive do
-      {:msg, %{topic: ^rand, body: ^msg16}} -> :ok
-      after 100 -> raise "timed out on sub"
-    end
-  end,
-  "req-reply-4" => fn ->
-    {:ok, %{body: "pong"}} = Gnat.request(pid, "echo", "ping")
-  end,
-}, time: 10, console: [comparison: false])
+ "sub-unsub-pub-16" => fn ->
+   rand = :crypto.strong_rand_bytes(8) |> Base.encode64
+   {:ok, subscription} = Gnat.sub(pid, self(), rand)
+   :ok = Gnat.unsub(pid, subscription, max_messages: 1)
+   :ok = Gnat.pub(pid, rand, msg16)
+   receive do
+     {:msg, %{topic: ^rand, body: ^msg16}} -> :ok
+     after 100 -> raise "timed out on sub"
+   end
+ end,
+ "req-reply-4" => fn ->
+   {:ok, %{body: "pong"}} = Gnat.request(pid, "echo", "ping")
+ end,
+}, time: 10, parallel: 8, console: [comparison: false])

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -196,10 +196,13 @@ defmodule Gnat do
     next_state = add_subscription_to_state(state, sid, receiver) |> Map.put(:next_sid, sid + 1)
     {:reply, {:ok, sid}, next_state}
   end
-  def handle_call({:pub, topic, message, opts}, _from, state) do
-    command = Command.build(:pub, topic, message, opts)
-    :ok = socket_write(state, command)
-    {:reply, :ok, state}
+  def handle_call({:pub, topic, message, opts}, from, state) do
+    commands = [Command.build(:pub, topic, message, opts)]
+    froms = [from]
+    {commands, froms} = receive_additional_pubs(commands, froms, 10)
+    :ok = socket_write(state, commands)
+    Enum.each(froms, fn(from) -> GenServer.reply(from, :ok) end)
+    {:noreply, state}
   end
   def handle_call({:request, request}, _from, %{next_sid: sid}=state) do
     sub = Command.build(:sub, request.inbox, sid, [])
@@ -270,6 +273,18 @@ defmodule Gnat do
       message: message,
     ])
     state
+  end
+
+  defp receive_additional_pubs(commands, froms, 0), do: {commands, froms}
+  defp receive_additional_pubs(commands, froms, how_many_more) do
+    receive do
+      {:"$gen_call", from, {:pub, topic, message, opts}} ->
+        commands = [Command.build(:pub, topic, message, opts) | commands]
+        froms = [from | froms]
+        receive_additional_pubs(commands, froms, how_many_more - 1)
+    after
+      0 -> {commands, froms}
+    end
   end
 
   defp update_subscriptions_after_delivering_message(%{receivers: receivers}=state, sid) do


### PR DESCRIPTION
I always wondered how much of a bottleneck it was for us to write small publishing packets to the TCP/SSL socket for each command so I decided to use the `pub128` benchmark in this project and experiment with the idea of accepting multiple `pub` commands at the same time, combining them into a single TCP send and then doing a `GenServer.reply` for each one of them.

This change almost doubled the publishing throughput. Below you can see the throughput numbers for various level of publishing clients and with/without tcp nodelay on the connection.

![gnat_publish_optimize](https://user-images.githubusercontent.com/80008/27959183-be0f2590-6326-11e7-94d1-a8ef67b8c91c.png)

> Using a localhost connection in this case was an attempt to narrow this down to CPU overhead and/or erlang scheduling overhead (ignoring networking performance for the moment). But maybe I should repeat these tests with a multi-node setup so we can test over an actual ethernet connection?

I'm curious if we think this type of optimization is worth it. The code is a bit more complex, but a nearly 2x improvement could be useful in some cases.

/cc @film42 @quixoten @abrandoned @newellista 