### PR TITLE
Optimize Throughput

### DIFF
--- a/bench.exs
+++ b/bench.exs
@@ -28,19 +28,19 @@ msg16="74c93e71c5aa03ad"
 
 tcp_packet = "MSG topic 1 128\r\n#{msg128}\r\n"
 Benchee.run(%{
-  "parse-128" => fn -> {_parser, [_msg]} = Gnat.Parser.new() |> Gnat.Parser.parse(tcp_packet) end,
+ "parse-128" => fn -> {_parser, [_msg]} = Gnat.Parser.new() |> Gnat.Parser.parse(tcp_packet) end,
   "pub - 128" => fn -> :ok = Gnat.pub(pid, "pub128", msg128) end,
-  "sub-unsub-pub-16" => fn ->
-    rand = :crypto.strong_rand_bytes(8) |> Base.encode64
-    {:ok, subscription} = Gnat.sub(pid, self(), rand)
-    :ok = Gnat.unsub(pid, subscription, max_messages: 1)
-    :ok = Gnat.pub(pid, rand, msg16)
-    receive do
-      {:msg, %{topic: ^rand, body: ^msg16}} -> :ok
-      after 100 -> raise "timed out on sub"
-    end
-  end,
-  "req-reply-4" => fn ->
-    {:ok, %{body: "pong"}} = Gnat.request(pid, "echo", "ping")
-  end,
-}, time: 10, console: [comparison: false])
+ "sub-unsub-pub-16" => fn ->
+   rand = :crypto.strong_rand_bytes(8) |> Base.encode64
+   {:ok, subscription} = Gnat.sub(pid, self(), rand)
+   :ok = Gnat.unsub(pid, subscription, max_messages: 1)
+   :ok = Gnat.pub(pid, rand, msg16)
+   receive do
+     {:msg, %{topic: ^rand, body: ^msg16}} -> :ok
+     after 100 -> raise "timed out on sub"
+   end
+ end,
+ "req-reply-4" => fn ->
+   {:ok, %{body: "pong"}} = Gnat.request(pid, "echo", "ping")
+ end,
+}, time: 10, parallel: 8, console: [comparison: false])

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -265,7 +265,7 @@ defmodule Gnat do
 
   defp process_message({:msg, topic, sid, reply_to, body}, state) do
     unless is_nil(state.receivers[sid]) do
-      send state.receivers[sid].recipient, {:msg, %{topic: topic, body: body, reply_to: reply_to, connection: self()}}
+      send state.receivers[sid].recipient, {:msg, %{topic: topic, body: body, reply_to: reply_to, gnat: self()}}
       update_subscriptions_after_delivering_message(state, sid)
     else
       Logger.error "#{__MODULE__} got message for sid #{sid}, but that is no longer registered"

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -262,7 +262,7 @@ defmodule Gnat do
 
   defp process_message({:msg, topic, sid, reply_to, body}, state) do
     unless is_nil(state.receivers[sid]) do
-      send state.receivers[sid].recipient, {:msg, %{topic: topic, body: body, reply_to: reply_to}}
+      send state.receivers[sid].recipient, {:msg, %{topic: topic, body: body, reply_to: reply_to, connection: self()}}
       update_subscriptions_after_delivering_message(state, sid)
     else
       Logger.error "#{__MODULE__} got message for sid #{sid}, but that is no longer registered"

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -300,7 +300,7 @@ defmodule Gnat do
     end
   end
 
-  def receive_additional_tcp_data(socket, packets, 0), do: Enum.reverse(packets)
+  def receive_additional_tcp_data(_socket, packets, 0), do: Enum.reverse(packets)
   def receive_additional_tcp_data(socket, packets, n) do
     receive do
       {:tcp, ^socket, data} ->

--- a/lib/gnat/handshake.ex
+++ b/lib/gnat/handshake.ex
@@ -5,7 +5,7 @@ defmodule Gnat.Handshake do
   This module provides a single function which handles all of the variations of establishing a connection to a gnatsd server and just returns {:ok, socket} or {:error, reason}
   """
   def connect(settings) do
-    host = settings.host |> to_char_list
+    host = settings.host |> to_charlist
     case :gen_tcp.connect(host, settings.port, settings.tcp_opts, settings.connection_timeout) do
       {:ok, tcp} -> perform_handshake(tcp, settings)
       result -> result


### PR DESCRIPTION
This follows the pattern in #61, but follows the same pattern for accepting data from the gnats brokers. This gives us ~50% increase in throughput on a [realistic benchmark](https://gist.github.com/mmmries/cf86af5149524155fc2eac3df4a9d948) that sends 128byte requests and gets back 1.3kb responses.

I've also added a `:gnat` key to the messages that get delivered so that client applications can easily setup multiple connections and send back a reply based on the data in the message they received. (ie they don't need to track the name or pid of a connection)

/cc @newellista @film42