### PR TITLE
Use a shared wildcard subscription to process all inbox messages

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -55,12 +55,19 @@ defmodule Gnat do
   @doc """
   Subscribe to a topic
 
+  Supported options:
+    * queue_group: a string that identifies which queue group you want to join
+    * as_request: a boolean that determines if you want to use the request wildcard subscription
+
+  NOTE: `as_request: true` cannot be used with any other option.
+
   By default each subscriber will receive a copy of every message on the topic.
   When a queue_group is supplied messages will be spread among the subscribers
   in the same group. (see [nats queueing](https://nats.io/documentation/concepts/nats-queueing/))
 
-  Supported options:
-    * queue_group: a string that identifies which queue group you want to join
+  The `as_request: true` option adds your subscription to the wildcard request subscription. By
+  sharing a subscription NATS does not need to update its internal map, which keeps your system
+  running super fast.
 
   ```
   {:ok, gnat} = Gnat.start_link()
@@ -69,9 +76,21 @@ defmodule Gnat do
     {:msg, %{topic: "topic", body: body}} ->
       IO.puts "Received: \#\{body\}"
   end
+
+  # OR
+
+  {:ok, gnat} = Gnat.start_link()
+  {:ok, inbox} = Gnat.new_inbox(gnat)
+  {:ok, subscription} = Gnat.sub(gnat, self(), inbox, as_request: true)
+  :ok = Gnat.pub(gnat, inbox, "how's the water?")
+  receive do
+    {:msg, %{topic: _topic, body: _body}=message} ->
+      IO.inspect(message)
+  end
+  Gnat.unsub(gnat, subscription)
   ```
   """
-  @spec sub(GenServer.server, pid(), String.t, keyword()) :: {:ok, non_neg_integer()}
+  @spec sub(GenServer.server, pid(), String.t, keyword()) :: {:ok, non_neg_integer()} | {:ok, String.t} | {:error, String.t}
   def sub(pid, subscriber, topic, opts \\ []), do: GenServer.call(pid, {:sub, subscriber, topic, opts})
 
   @doc """
@@ -141,6 +160,9 @@ defmodule Gnat do
   @doc """
   Unsubscribe from a topic
 
+  Supported options:
+    * max_messages: number of messages to be received before automatically unsubscribed
+
   This correlates to the [UNSUB](http://nats.io/documentation/internals/nats-protocol/#UNSUB) command in the nats protocol.
   By default the unsubscribe is affected immediately, but an optional `max_messages` value can be provided which will allow
   `max_messages` to be received before affecting the unsubscribe.
@@ -154,7 +176,7 @@ defmodule Gnat do
   :ok = Gnat.unsub(gnat, subscription, max_messages: 2)
   ```
   """
-  @spec unsub(GenServer.server, non_neg_integer(), keyword()) :: :ok
+  @spec unsub(GenServer.server, non_neg_integer() | String.t, keyword()) :: :ok
   def unsub(pid, sid, opts \\ []), do: GenServer.call(pid, {:unsub, sid, opts})
 
   @doc """
@@ -230,6 +252,15 @@ defmodule Gnat do
     socket_close(state)
     {:stop, :normal, :ok, state}
   end
+  def handle_call({:sub, receiver, topic, [as_request: true]}, _from, state) do
+    if String.contains?(topic, state.request_inbox_prefix) do
+      state = %{state | request_receivers: Map.put(state.request_receivers, topic, receiver)}
+      {:reply, {:ok, topic}, state}
+    else
+      error = "When subscribing as a request, you must use the new_inbox() method to create your topic."
+      {:reply, {:error, error}, state}
+    end
+  end
   def handle_call({:sub, receiver, topic, opts}, _from, %{next_sid: sid}=state) do
     sub = Command.build(:sub, topic, sid, opts)
     :ok = socket_write(state, sub)
@@ -256,6 +287,16 @@ defmodule Gnat do
     state = add_subscription_to_state(state, sid, request.recipient) |> cleanup_subscription_from_state(sid, max_messages: 1)
     next_sid = sid + 1
     {:reply, {:ok, sid}, %{state | next_sid: next_sid}}
+  end
+  # When the SID is a string, it's a topic, which is used as a key in the request receiver map.
+  def handle_call({:unsub, topic, _opts}, _from, state) when is_binary(topic) do
+    if Map.has_key?(state.request_receivers, topic) do
+      request_receivers = Map.delete(state.request_receivers, topic)
+      new_state = %{state | request_receivers: request_receivers}
+      {:reply, :ok, new_state}
+    else
+      {:reply, :ok, state}
+    end
   end
   def handle_call({:unsub, sid, opts}, _from, %{receivers: receivers}=state) do
     case Map.has_key?(receivers, sid) do
@@ -307,6 +348,7 @@ defmodule Gnat do
   defp process_message({:msg, topic, @request_sid, reply_to, body}, state) do
     if Map.has_key?(state.request_receivers, topic) do
       send state.request_receivers[topic], {:msg, %{topic: topic, body: body, reply_to: reply_to, gnat: self()}}
+      state
     else
       Logger.error "#{__MODULE__} got a response for a request, but that is no longer registered"
       state

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -132,14 +132,14 @@ defmodule Gnat do
   @spec request(GenServer.server, String.t, binary(), keyword()) :: {:ok, message} | {:error, :timeout}
   def request(pid, topic, body, opts \\ []) do
     receive_timeout = Keyword.get(opts, :receive_timeout, 60_000)
-    {:ok, inbox} = new_inbox(pid)
-    {:ok, subscription} = GenServer.call(pid, {:request, %{recipient: self(), inbox: inbox, body: body, topic: topic}})
-    receive do
-      {:msg, %{topic: ^inbox}=msg} -> {:ok, msg}
+    {:ok, subscription} = GenServer.call(pid, {:request, %{recipient: self(), body: body, topic: topic}})
+    response = receive do
+      {:msg, %{topic: ^subscription}=msg} -> {:ok, msg}
       after receive_timeout ->
-        :ok = unsub(pid, subscription)
         {:error, :timeout}
     end
+    :ok = unsub(pid, subscription)
+    response
   end
 
   @doc """
@@ -275,18 +275,15 @@ defmodule Gnat do
     Enum.each(froms, fn(from) -> GenServer.reply(from, :ok) end)
     {:noreply, state}
   end
-  def handle_call({:new_inbox}, _from, %{request_inbox_prefix: request_inbox_prefix}=state) do
-    inbox = request_inbox_prefix <> nuid()
-    {:reply, {:ok, inbox}, state}
+  def handle_call({:new_inbox}, _from, state) do
+    {:reply, {:ok, make_new_inbox(state)}, state}
   end
-  def handle_call({:request, request}, _from, %{next_sid: sid}=state) do
-    sub = Command.build(:sub, request.inbox, sid, [])
-    unsub = Command.build(:unsub, sid, [max_messages: 1])
-    pub = Command.build(:pub, request.topic, request.body, reply_to: request.inbox)
-    :ok = socket_write(state, [sub, unsub, pub])
-    state = add_subscription_to_state(state, sid, request.recipient) |> cleanup_subscription_from_state(sid, max_messages: 1)
-    next_sid = sid + 1
-    {:reply, {:ok, sid}, %{state | next_sid: next_sid}}
+  def handle_call({:request, request}, _from, state) do
+    inbox = make_new_inbox(state)
+    new_state = %{state | request_receivers: Map.put(state.request_receivers, inbox, request.recipient)}
+    pub = Command.build(:pub, request.topic, request.body, reply_to: inbox)
+    :ok = socket_write(new_state, [pub])
+    {:reply, {:ok, inbox}, new_state}
   end
   # When the SID is a string, it's a topic, which is used as a key in the request receiver map.
   def handle_call({:unsub, topic, _opts}, _from, state) when is_binary(topic) do
@@ -320,6 +317,8 @@ defmodule Gnat do
     :ok = socket_write(state, [sub])
     add_subscription_to_state(state, @request_sid, self())
   end
+
+  defp make_new_inbox(%{request_inbox_prefix: prefix}), do: prefix <> nuid()
 
   defp nuid(), do: :crypto.strong_rand_bytes(12) |> Base.encode64
 

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -111,7 +111,7 @@ defmodule Gnat do
   @spec request(GenServer.server, String.t, binary(), keyword()) :: {:ok, message} | {:error, :timeout}
   def request(pid, topic, body, opts \\ []) do
     receive_timeout = Keyword.get(opts, :receive_timeout, 60_000)
-    inbox = "INBOX-#{:crypto.strong_rand_bytes(12) |> Base.encode64}"
+    {:ok, inbox} = new_inbox(pid)
     {:ok, subscription} = GenServer.call(pid, {:request, %{recipient: self(), inbox: inbox, body: body, topic: topic}})
     receive do
       {:msg, %{topic: ^inbox}=msg} -> {:ok, msg}
@@ -120,6 +120,21 @@ defmodule Gnat do
         {:error, :timeout}
     end
   end
+
+  @doc """
+  Get a new request inbox
+
+  As an optimization, the gnats connection maintains a single subscription to route all responses from "requests". Which
+  are of the format `_INBOX.<connection_id>.<request_id>`. Use this method to generate a new inbox.
+
+  ```
+  {:ok, gnat} = Gnat.start_link()
+  {:ok, inbox} = Gnat.new_inbox(gnat)
+  IO.inspect(inbox) #=> "_INBOX.Jhf7AcTGP3x4dAV9.gV4Xzwd0BmdmJMBx"
+  ```
+  """
+  @spec new_inbox(GenServer.server) :: {:ok, String.t}
+  def new_inbox(pid), do: GenServer.call(pid, {:new_inbox})
 
   @doc """
   Unsubscribe from a topic
@@ -162,10 +177,17 @@ defmodule Gnat do
   @impl GenServer
   def init(connection_settings) do
     connection_settings = Map.merge(@default_connection_settings, connection_settings)
+    request_inbox_prefix = "_INBOX.#{nuid()}."
     case Gnat.Handshake.connect(connection_settings) do
       {:ok, socket} ->
         parser = Parser.new
-        {:ok, %{socket: socket, connection_settings: connection_settings, next_sid: 1, receivers: %{}, parser: parser}}
+        {:ok, %{socket: socket,
+                connection_settings: connection_settings,
+                next_sid: 1,
+                receivers: %{},
+                parser: parser,
+                request_receivers: %{},
+                request_inbox_prefix: request_inbox_prefix}}
       {:error, reason} ->
         {:stop, reason}
     end
@@ -217,6 +239,10 @@ defmodule Gnat do
     Enum.each(froms, fn(from) -> GenServer.reply(from, :ok) end)
     {:noreply, state}
   end
+  def handle_call({:new_inbox}, _from, %{request_inbox_prefix: request_inbox_prefix}=state) do
+    inbox = request_inbox_prefix <> nuid()
+    {:reply, {:ok, inbox}, state}
+  end
   def handle_call({:request, request}, _from, %{next_sid: sid}=state) do
     sub = Command.build(:sub, request.inbox, sid, [])
     unsub = Command.build(:unsub, sid, [max_messages: 1])
@@ -240,6 +266,8 @@ defmodule Gnat do
     :ok = socket_write(state, "PING\r\n")
     {:reply, :ok, Map.put(state, :pinger, pinger)}
   end
+
+  defp nuid(), do: :crypto.strong_rand_bytes(12) |> Base.encode64
 
   defp socket_close(%{socket: socket, connection_settings: %{tls: true}}), do: :ssl.close(socket)
   defp socket_close(%{socket: socket}), do: :gen_tcp.close(socket)

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -201,7 +201,6 @@ defmodule Gnat do
   @impl GenServer
   def init(connection_settings) do
     connection_settings = Map.merge(@default_connection_settings, connection_settings)
-    request_inbox_prefix = "_INBOX.#{nuid()}."
     case Gnat.Handshake.connect(connection_settings) do
       {:ok, socket} ->
         parser = Parser.new
@@ -211,7 +210,7 @@ defmodule Gnat do
                   receivers: %{},
                   parser: parser,
                   request_receivers: %{},
-                  request_inbox_prefix: request_inbox_prefix}
+                  request_inbox_prefix: "_INBOX.#{nuid()}."}
 
         state = create_request_subscription(state)
         {:ok, state}

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -181,13 +181,16 @@ defmodule Gnat do
     case Gnat.Handshake.connect(connection_settings) do
       {:ok, socket} ->
         parser = Parser.new
-        {:ok, %{socket: socket,
-                connection_settings: connection_settings,
-                next_sid: 1,
-                receivers: %{},
-                parser: parser,
-                request_receivers: %{},
-                request_inbox_prefix: request_inbox_prefix}}
+        state = %{socket: socket,
+                  connection_settings: connection_settings,
+                  next_sid: 1,
+                  receivers: %{},
+                  parser: parser,
+                  request_receivers: %{},
+                  request_inbox_prefix: request_inbox_prefix}
+
+        state = create_request_subscription(state)
+        {:ok, state}
       {:error, reason} ->
         {:stop, reason}
     end
@@ -265,6 +268,14 @@ defmodule Gnat do
   def handle_call({:ping, pinger}, _from, state) do
     :ok = socket_write(state, "PING\r\n")
     {:reply, :ok, Map.put(state, :pinger, pinger)}
+  end
+
+  defp create_request_subscription(%{request_inbox_prefix: request_inbox_prefix}=state) do
+    # Example: "_INBOX.Jhf7AcTGP3x4dAV9.*"
+    wildcard_inbox_topic = request_inbox_prefix <> "*"
+    sub = Command.build(:sub, wildcard_inbox_topic, 0, [])
+    :ok = socket_write(state, [sub])
+    add_subscription_to_state(state, 0, self())
   end
 
   defp nuid(), do: :crypto.strong_rand_bytes(12) |> Base.encode64

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -141,15 +141,18 @@ defmodule GnatTest do
   test "request-reply convenience function" do
     topic = "req-resp"
     {:ok, pid} = Gnat.start_link()
-    spin_up_echo_server_on_topic(pid, topic)
+    spin_up_echo_server_on_topic(self(), pid, topic)
+    # Wait for server to spawn and subscribe.
+    assert_receive(true, 100)
     {:ok, msg} = Gnat.request(pid, topic, "ohai", receive_timeout: 500)
     assert msg.body == "ohai"
   end
 
-  defp spin_up_echo_server_on_topic(gnat, topic) do
+  defp spin_up_echo_server_on_topic(ready, gnat, topic) do
     spawn(fn ->
       {:ok, subscription} = Gnat.sub(gnat, self(), topic)
       :ok = Gnat.unsub(gnat, subscription, max_messages: 1)
+      send ready, true
       receive do
         {:msg, %{topic: ^topic, body: body, reply_to: reply_to}} ->
           Gnat.pub(gnat, reply_to, body)

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -82,6 +82,21 @@ defmodule GnatTest do
     :ok = Gnat.stop(pid)
   end
 
+  test "subscribing and unsubscribing as a request" do
+    {:ok, gnat} = Gnat.start_link()
+    {:ok, inbox} = Gnat.new_inbox(gnat)
+    {:ok, subscription} = Gnat.sub(gnat, self(), inbox, as_request: true)
+    :ok = Gnat.pub(gnat, inbox, "how's the water?")
+    assert_receive {:msg, %{topic: ^inbox, body: "how's the water?"}}, 500
+    Gnat.unsub(gnat, subscription)
+  end
+
+  test "subscribing as a request without the connection inbox prefix returns an error" do
+    {:ok, gnat} = Gnat.start_link()
+    response = Gnat.sub(gnat, self(), "not_a_request_inbox", as_request: true)
+    assert response == {:error, "When subscribing as a request, you must use the new_inbox() method to create your topic."}
+  end
+
   test "subscribing to the same topic multiple times" do
     {:ok, pid} = Gnat.start_link()
     {:ok, _sub1} = Gnat.sub(pid, self(), "dup")


### PR DESCRIPTION
It turns out subscribing and unsubscribing frequently is not good for NATS. It needs to lock its subscription list before it can perform an update, so churning through subscriptions will slow your entire system down. The good people at apcera started migrating to this pattern. This is my first attempt at making it work. Here's what's changed:

1. When we call `Gnat.start_link` we create a new subscription with SID `0` to the `_INBOX.<random_id_for_the_connection>.*` topic. Example: ` _INBOX.Jhf7AcTGP3x4dAV9.*`.
2. There's a new `Gnat.new_inbox` method that generates a new random inbox appended to the connection inbox prefix. Example: `_INBOX.Jhf7AcTGP3x4dAV9.gV4Xzwd0BmdmJMBx`.
3. The `Gnat.sub` method now has an `as_request: true` option which can be provided to update the request receivers map instead of creating a new subscription. When `as_request: true` is provided, we return the inbox string as the SID. This let's us know _which_ key we should remove from the request receivers map when we unsub. If the topic provided to `Gant.sub` with `as_request: true` doesn't contain the connection inbox prefix, we return an error. I don't love this. Any feedback? 
4. The `Gnat.unsub` method can now looks to see if the SID is a binary or number. If a binary, we attempt to remove it from the new request receivers map. Otherwise, same old story. The only weird thing here is that there's no support for `max_messages: N` with a "request subscription". I'm open to adding this here or in a follow up PR. Thoughts?
5. Finally, the `Gnat.request` method functions the same. Only the insides have been altered to be more efficient. There's still room for improvement (like removing the explicit `unsubscribe`).

cc @mmmries @newellista @jjcarstens 