### PR TITLE
add support for parsing +OK messages and property tests

### DIFF
--- a/lib/gnat/parser.ex
+++ b/lib/gnat/parser.ex
@@ -48,6 +48,7 @@ defmodule Gnat.Parser do
 
   defp parse_command("PING", _, body), do: {:ping, body}
   defp parse_command("PONG", _, body), do: {:pong, body}
+  defp parse_command("+OK", _, body), do: {:ok, body}
   defp parse_command("MSG", [topic, sidstr, sizestr], body), do: parse_command("MSG", [topic, sidstr, nil, sizestr], body)
   defp parse_command("MSG", [topic, sidstr, reply_to, sizestr], body) do
     sid = String.to_integer(sidstr)

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -5,9 +5,25 @@ defmodule Gnat.Generators do
     elements('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
   end
 
-  # subscription names (subject names with * and > added)
   def delimiter, do: let(chunks <- non_empty(list(delimiter_char())), do: Enum.join(chunks, ""))
+
   def delimiter_char, do: union([" ","\t"])
+
+  def error do
+    let chars <- list(error_char) do
+      %{binary: "-ERR '#{List.to_string(chars)}'\r\n"}
+    end
+  end
+
+  def error_char do
+    elements(' 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
+  end
+
+  def ok, do: %{binary: "+OK\r\n"}
+
+  def ping, do: %{binary: "PING\r\n"}
+
+  def pong, do: %{binary: "PONG\r\n"}
 
   # generates a map containing the binary encoded message and attributes for which generated
   # sid, subject, payload and reply_to topic were used in the encoded message
@@ -46,6 +62,10 @@ defmodule Gnat.Generators do
 
   def payload(size), do: binary(size)
 
+  def protocol_message do
+    union([ok(), ping(), pong(), error(), message()])
+  end
+
   # according to the spec sid's can be alphanumeric, but our client only generates
   # non-negative integers and we only receive back our own sids
   def sid, do: non_neg_integer()
@@ -60,6 +80,9 @@ defmodule Gnat.Generators do
       ))
     ))
   end
+
+  # TODO subsription names are like subject names, but they can have wildcards
+  # There is a special case where a user can subscribe to ">" to subscribe to all topics
 
   def reply_to, do: subject()
 end


### PR DESCRIPTION
Adds another 2 property tests for the parser that will randomly generate all kinds of protocol messages (`PING`,`PONG`,`+OK`,`-ERR...` and `MSG...`). One test feeds these protocol messages into the parser one at a time, the other test glues them together into one big string and then randomly chunks them up to make sure that we can parse them with any arbitrary byte splitting that might happen at the networking level.