### PR TITLE
Property test gnat connection

### DIFF
--- a/test/gnat_property_test.exs
+++ b/test/gnat_property_test.exs
@@ -1,0 +1,31 @@
+defmodule GnatPropertyTest do
+  use ExUnit.Case, async: true
+  use PropCheck
+  import Gnat.Generators, only: [message: 0]
+  @numtests (System.get_env("N") || "100") |> String.to_integer
+
+  @tag :property
+  property "can publish to random subjects" do
+    numtests(@numtests * 10, forall %{subject: subject, payload: payload} <- message() do
+      Gnat.pub(:test_connection, subject, payload) == :ok
+    end)
+  end
+
+  @tag :property
+  property "can subscribe, publish, receive and unsubscribe from subjects" do
+    numtests(@numtests * 10, forall %{subject: subject, payload: payload} <- message() do
+      {:ok, ref} = Gnat.sub(:test_connection, self(), subject)
+      :ok = Gnat.pub(:test_connection, subject, payload)
+      assert_receive {:msg, %{topic: ^subject, body: ^payload, reply_to: nil}}, 500
+      Gnat.unsub(:test_connection, ref) == :ok
+    end)
+  end
+
+  @tag :property
+  property "can make requests to an echo endpoint" do
+    numtests(@numtests * 10, forall %{subject: subject, payload: payload} <- message() do
+      {:ok, msg} = Gnat.request(:test_connection, "rpc.#{subject}", payload)
+      msg.body == payload
+    end)
+  end
+end

--- a/test/gnat_property_test.exs
+++ b/test/gnat_property_test.exs
@@ -6,14 +6,14 @@ defmodule GnatPropertyTest do
 
   @tag :property
   property "can publish to random subjects" do
-    numtests(@numtests * 10, forall %{subject: subject, payload: payload} <- message() do
+    numtests(@numtests * 2, forall %{subject: subject, payload: payload} <- message() do
       Gnat.pub(:test_connection, subject, payload) == :ok
     end)
   end
 
   @tag :property
   property "can subscribe, publish, receive and unsubscribe from subjects" do
-    numtests(@numtests * 10, forall %{subject: subject, payload: payload} <- message() do
+    numtests(@numtests * 2, forall %{subject: subject, payload: payload} <- message() do
       {:ok, ref} = Gnat.sub(:test_connection, self(), subject)
       :ok = Gnat.pub(:test_connection, subject, payload)
       assert_receive {:msg, %{topic: ^subject, body: ^payload, reply_to: nil}}, 500
@@ -23,7 +23,7 @@ defmodule GnatPropertyTest do
 
   @tag :property
   property "can make requests to an echo endpoint" do
-    numtests(@numtests * 10, forall %{subject: subject, payload: payload} <- message() do
+    numtests(@numtests * 2, forall %{subject: subject, payload: payload} <- message() do
       {:ok, msg} = Gnat.request(:test_connection, "rpc.#{subject}", payload)
       msg.body == payload
     end)
@@ -31,7 +31,7 @@ defmodule GnatPropertyTest do
 
   @tag :property
   property "auto-unsubscribes after n messages" do
-    numtests(@numtests * 2, forall {%{subject: subject, payload: payload}, max_messaages} <- {message(), pos_integer()} do
+    numtests(@numtests, forall {%{subject: subject, payload: payload}, max_messaages} <- {message(), pos_integer()} do
       {:ok, ref} = Gnat.sub(:test_connection, self(), subject)
       :ok = Gnat.unsub(:test_connection, ref, max_messages: max_messaages)
       Enum.each(1..max_messaages, fn(_) ->


### PR DESCRIPTION
This adds 4 additional property tests that exercise the full library.

* publishes tons of random messages to randomly subjects
* subscribe, publish, receive and unsub from a bunch of random subjects
* perform a bunch of request-reply cycles against an echo server (setup in the `test_helper.exs`)
* test subscribe/unsubscribe with a random max message and then make sure that we receive the expected number of publishes before the subscription dissapears

While adding these tests I also added a `Gnat.active_subscriptions/1` to check the number of subscriptions the connection currently knows about and also made the `receive_additional_tcp_data` into a private function.