### PR TITLE
Single request sub

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -207,7 +207,6 @@ defmodule Gnat do
   @impl GenServer
   def init(connection_settings) do
     connection_settings = Map.merge(@default_connection_settings, connection_settings)
-    request_inbox_prefix = "_INBOX.#{nuid()}."
     case Gnat.Handshake.connect(connection_settings) do
       {:ok, socket} ->
         parser = Parser.new
@@ -217,7 +216,7 @@ defmodule Gnat do
                   receivers: %{},
                   parser: parser,
                   request_receivers: %{},
-                  request_inbox_prefix: request_inbox_prefix}
+                  request_inbox_prefix: "_INBOX.#{nuid()}."}
 
         state = create_request_subscription(state)
         {:ok, state}

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -18,6 +18,8 @@ defmodule Gnat do
     tls: false,
   }
 
+  @request_sid 0
+
   @doc """
   Starts a connection to a nats broker
 
@@ -283,9 +285,9 @@ defmodule Gnat do
   defp create_request_subscription(%{request_inbox_prefix: request_inbox_prefix}=state) do
     # Example: "_INBOX.Jhf7AcTGP3x4dAV9.*"
     wildcard_inbox_topic = request_inbox_prefix <> "*"
-    sub = Command.build(:sub, wildcard_inbox_topic, 0, [])
+    sub = Command.build(:sub, wildcard_inbox_topic, @request_sid, [])
     :ok = socket_write(state, [sub])
-    add_subscription_to_state(state, 0, self())
+    add_subscription_to_state(state, @request_sid, self())
   end
 
   defp nuid(), do: :crypto.strong_rand_bytes(12) |> Base.encode64
@@ -312,6 +314,14 @@ defmodule Gnat do
     %{state | receivers: receivers}
   end
 
+  defp process_message({:msg, topic, @request_sid, reply_to, body}, state) do
+    if Map.has_key?(state.request_receivers, topic) do
+      send state.request_receivers[topic], {:msg, %{topic: topic, body: body, reply_to: reply_to, gnat: self()}}
+    else
+      Logger.error "#{__MODULE__} got a response for a request, but that is no longer registered"
+      state
+    end
+  end
   defp process_message({:msg, topic, sid, reply_to, body}, state) do
     unless is_nil(state.receivers[sid]) do
       send state.receivers[sid].recipient, {:msg, %{topic: topic, body: body, reply_to: reply_to, gnat: self()}}

--- a/test/gnat_property_test.exs
+++ b/test/gnat_property_test.exs
@@ -35,14 +35,16 @@ defmodule GnatPropertyTest do
       {:ok, ref} = Gnat.sub(:test_connection, self(), subject)
       :ok = Gnat.unsub(:test_connection, ref, max_messages: max_messaages)
       Enum.each(1..max_messaages, fn(_) ->
-        {:ok, 1} = Gnat.active_subscriptions(:test_connection)
+        {:ok, 2} = Gnat.active_subscriptions(:test_connection)
         :ok = Gnat.pub(:test_connection, subject, payload)
         receive do
           {:msg, %{body: ^payload}} -> :ok
           after 100 -> raise "did not receive message from #{subject} within 100ms"
         end
       end)
-      Gnat.active_subscriptions(:test_connection) == {:ok, 0}
+      # Note: we always keep 1 active subscription setup for the purpose of request-reply
+      # usage. So there should still be one after the rest have cleaned themselves up.
+      Gnat.active_subscriptions(:test_connection) == {:ok, 1}
     end)
   end
 end

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -82,21 +82,6 @@ defmodule GnatTest do
     :ok = Gnat.stop(pid)
   end
 
-  test "subscribing and unsubscribing as a request" do
-    {:ok, gnat} = Gnat.start_link()
-    {:ok, inbox} = Gnat.new_inbox(gnat)
-    {:ok, subscription} = Gnat.sub(gnat, self(), inbox, as_request: true)
-    :ok = Gnat.pub(gnat, inbox, "how's the water?")
-    assert_receive {:msg, %{topic: ^inbox, body: "how's the water?"}}, 500
-    Gnat.unsub(gnat, subscription)
-  end
-
-  test "subscribing as a request without the connection inbox prefix returns an error" do
-    {:ok, gnat} = Gnat.start_link()
-    response = Gnat.sub(gnat, self(), "not_a_request_inbox", as_request: true)
-    assert response == {:error, "When subscribing as a request, you must use the new_inbox() method to create your topic."}
-  end
-
   test "subscribing to the same topic multiple times" do
     {:ok, pid} = Gnat.start_link()
     {:ok, _sub1} = Gnat.sub(pid, self(), "dup")

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -141,15 +141,18 @@ defmodule GnatTest do
   test "request-reply convenience function" do
     topic = "req-resp"
     {:ok, pid} = Gnat.start_link()
-    spin_up_echo_server_on_topic(pid, topic)
+    spin_up_echo_server_on_topic(self(), pid, topic)
+    # Wait for server to spawn and subscribe.
+    assert_receive(true, 100)
     {:ok, msg} = Gnat.request(pid, topic, "ohai", receive_timeout: 500)
     assert msg.body == "ohai"
   end
 
-  defp spin_up_echo_server_on_topic(gnat, topic) do
+  defp spin_up_echo_server_on_topic(ready, gnat, topic) do
     spawn(fn ->
       {:ok, subscription} = Gnat.sub(gnat, self(), topic)
       :ok = Gnat.unsub(gnat, subscription, max_messages: 1)
+      send ready, true
       receive do
         {:msg, %{topic: ^topic, body: body, reply_to: reply_to}} ->
           Gnat.pub(gnat, reply_to, body)

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -82,6 +82,21 @@ defmodule GnatTest do
     :ok = Gnat.stop(pid)
   end
 
+  test "subscribing and unsubscribing as a request" do
+    {:ok, gnat} = Gnat.start_link()
+    {:ok, inbox} = Gnat.new_inbox(gnat)
+    {:ok, subscription} = Gnat.sub(gnat, self(), inbox, as_request: true)
+    :ok = Gnat.pub(gnat, inbox, "how's the water?")
+    assert_receive {:msg, %{topic: ^inbox, body: "how's the water?"}}, 500
+    Gnat.unsub(gnat, subscription)
+  end
+
+  test "subscribing as a request without the connection inbox prefix returns an error" do
+    {:ok, gnat} = Gnat.start_link()
+    response = Gnat.sub(gnat, self(), "not_a_request_inbox", as_request: true)
+    assert response == {:error, "When subscribing as a request, you must use the new_inbox() method to create your topic."}
+  end
+
   test "subscribing to the same topic multiple times" do
     {:ok, pid} = Gnat.start_link()
     {:ok, _sub1} = Gnat.sub(pid, self(), "dup")


### PR DESCRIPTION
This is a rebase of #69

This code is now being exercised the property tests introduced in.

@film42 was the ideas of `sub + :as_request` to enable custom request/reply flows like the one that MX uses? If so, I might take a stab at an alternate method to enabling those without using the `sub` function. Just want to make sure I understand before suggesting any changes.