### PR TITLE
require elixir 1.5+, test on last 3 major release of elixir and OTP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ elixir:
  - 1.5.3
  - 1.6.6
  - 1.7.3
+matrix:
+  exclude:
+    elixir: 1.5.3
+    otp_release: 21.1
 env:
  - N=400 MIX_ENV=test
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: elixir
 otp_release:
- - 18.3
  - 19.3
  - 20.3
+ - 21.1
 elixir:
- - 1.4.5
  - 1.5.3
- - 1.6.4
+ - 1.6.6
+ - 1.7.3
 env:
  - N=400 MIX_ENV=test
 branches:
@@ -14,13 +14,13 @@ branches:
     - master
 before_install:
  - wget https://github.com/nats-io/gnatsd/releases/download/v0.9.6/gnatsd-v0.9.6-linux-amd64.zip
- - unzip gnatsd-v0.9.6-linux-amd64.zip
- - ./gnatsd-v0.9.6-linux-amd64/gnatsd &
+ - unzip gnatsd-v1.3.0-linux-amd64.zip
+ - ./gnatsd-v1.3.0-linux-amd64/gnatsd &
 
 before_script:
- - ./gnatsd-v0.9.6-linux-amd64/gnatsd -p 4223 --user bob --pass alice &
- - ./gnatsd-v0.9.6-linux-amd64/gnatsd -p 4224 --tls --tlscert test/fixtures/server.pem --tlskey test/fixtures/key.pem &
- - ./gnatsd-v0.9.6-linux-amd64/gnatsd -p 4225 --tls --tlscert test/fixtures/server.pem --tlskey test/fixtures/key.pem --tlscacert test/fixtures/ca.pem --tlsverify &
+ - ./gnatsd-v1.3.0-linux-amd64/gnatsd -p 4223 --user bob --pass alice &
+ - ./gnatsd-v1.3.0-linux-amd64/gnatsd -p 4224 --tls --tlscert test/fixtures/server.pem --tlskey test/fixtures/key.pem &
+ - ./gnatsd-v1.3.0-linux-amd64/gnatsd -p 4225 --tls --tlscert test/fixtures/server.pem --tlskey test/fixtures/key.pem --tlscacert test/fixtures/ca.pem --tlsverify &
 
 script:
   - mix compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ branches:
   only:
     - master
 before_install:
- - wget https://github.com/nats-io/gnatsd/releases/download/v0.9.6/gnatsd-v0.9.6-linux-amd64.zip
+ - wget https://github.com/nats-io/gnatsd/releases/download/v1.3.0/gnatsd-v1.3.0-linux-amd64.zip
  - unzip gnatsd-v1.3.0-linux-amd64.zip
  - ./gnatsd-v1.3.0-linux-amd64/gnatsd &
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule Gnat.Mixfile do
   def project do
     [
       app: :gnat,
-      version: "0.4.2",
-      elixir: "~> 1.4",
+      version: "0.5.0",
+      elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/test/gnat_test.exs
+++ b/test/gnat_test.exs
@@ -165,9 +165,9 @@ defmodule GnatTest do
     {:ok, gnat} = Gnat.start_link()
     assert capture_log(fn ->
       Process.flag(:trap_exit, true)
-      Gnat.sub(gnat, self(), "invalid\r\nsubject")
+      Gnat.sub(gnat, self(), "invalid. subject")
       Process.sleep(20) # errors are reported asynchronously so we need to wait a moment
-    end) =~ "Parser Error"
+    end) =~ "'Invalid Subject'"
   end
 
   test "connection timeout" do


### PR DESCRIPTION
Drop support for Elixir `1.4.X` and OTP `18.X`. We'll test against the latest Elixir 1.5, 1.6 and 1.7 releases and the latest minor versions of OTP 19, 20 and 21.