### PR TITLE
Fix bug

### DIFF
--- a/lib/gnat/consumer_supervisor.ex
+++ b/lib/gnat/consumer_supervisor.ex
@@ -70,7 +70,7 @@ defmodule Gnat.ConsumerSupervisor do
     end
   end
 
-  def handle_info({:DOWN, _ref, :process, connection_pid, _reason}, %{connnection_pid: connection_pid}=state) do
+  def handle_info({:DOWN, _ref, :process, connection_pid, _reason}, %{connection_pid: connection_pid}=state) do
     Process.send_after(self(), :connect, 2_000)
     {:noreply, %{state | status: :disconnected, connection_pid: nil, subscriptions: []}}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Gnat.Mixfile do
   def project do
     [
       app: :gnat,
-      version: "0.5.1",
+      version: "0.5.2",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env == :prod,


### PR DESCRIPTION
😭 Found this bug after using `gnat` in a side project. I had a typo in my pattern match which meant that we never matched on the clause where we handle the connection being down and needing to re-connect / re-subscribe.

@jjcarstens @newellista I think you might want to upgrade to `0.5.2` to pickup this fix for `brokaw`