### PR TITLE
add telemetry to the project

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,6 +32,7 @@ defmodule Gnat.Mixfile do
       {:ex_doc, "~> 0.15", only: :dev},
       {:jason, "~> 1.1"},
       {:propcheck, "~> 1.0", only: :test},
+      {:telemetry, "~> 0.2"},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -11,4 +11,5 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "propcheck": {:hex, :propcheck, "1.0.4", "f83174301b637bce011a4ebf0e4f10e9bae38d6eefebdd117677c7884bc99aa4", [:mix], [{:proper, "~> 1.2.0", [hex: :proper, repo: "hexpm", optional: false]}], "hexpm"},
   "proper": {:hex, :proper, "1.2.0", "1466492385959412a02871505434e72e92765958c60dba144b43863554b505a4", [:make, :mix, :rebar3], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.2.0", "5b40caa3efe4deb30fb12d7cd8ed4f556f6d6bd15c374c2366772161311ce377", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
@entone this is an alternative to you wrapping the `gnat` library. It should allow you to run something like:

* `Telemetry.attach("record_pubs", [:gnat, :pub], Publish, :instrument, nil)`
* `Telemetry.attach("record_subs", [:gnat, :sub], Subscription, :instrument, nil)`
* `Telemetry.attach("record_requests", [:gnat, :request], Request, :instrument, nil)`
* `Telemetry.attach("record_messages", [:gnat, :message_received], Message, :instrument, nil)`
* `Telemetry.attach("record_unsubs", [:gnat, :unsub], Unsubscribe, :instrument, nil)`

Would that give you all the instrumentation you need? Each of the events have metadata about the `topic` except for the `[:gnat, :unsub]` event because we only have the `sid`.  I also ran the benchmarks script before and after these changes and there was no significant differences.
