### PR TITLE
update to the latest telemetry

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -75,7 +75,7 @@ defmodule Gnat do
   def sub(pid, subscriber, topic, opts \\ []) do
     start = :erlang.monotonic_time()
     result = GenServer.call(pid, {:sub, subscriber, topic, opts})
-    Telemetry.execute([:gnat, :sub], :erlang.monotonic_time() - start, %{topic: topic})
+    :telemetry.execute([:gnat, :sub], :erlang.monotonic_time() - start, %{topic: topic})
     result
   end
 
@@ -99,7 +99,7 @@ defmodule Gnat do
   def pub(pid, topic, message, opts \\ []) do
     start = :erlang.monotonic_time()
     result = GenServer.call(pid, {:pub, topic, message, opts})
-    Telemetry.execute([:gnat, :pub], :erlang.monotonic_time() - start, %{topic: topic})
+    :telemetry.execute([:gnat, :pub], :erlang.monotonic_time() - start, %{topic: topic})
     result
   end
 
@@ -131,7 +131,7 @@ defmodule Gnat do
         {:error, :timeout}
     end
     :ok = unsub(pid, subscription)
-    Telemetry.execute([:gnat, :request], :erlang.monotonic_time() - start, %{topic: topic})
+    :telemetry.execute([:gnat, :request], :erlang.monotonic_time() - start, %{topic: topic})
     response
   end
 
@@ -158,7 +158,7 @@ defmodule Gnat do
   def unsub(pid, sid, opts \\ []) do
     start = :erlang.monotonic_time()
     result = GenServer.call(pid, {:unsub, sid, opts})
-    Telemetry.execute([:gnat, :unsub], :erlang.monotonic_time() - start)
+    :telemetry.execute([:gnat, :unsub], :erlang.monotonic_time() - start)
     result
   end
 
@@ -335,7 +335,7 @@ defmodule Gnat do
   end
   defp process_message({:msg, topic, sid, reply_to, body}, state) do
     unless is_nil(state.receivers[sid]) do
-      Telemetry.execute([:gnat, :message_received], 1, %{topic: topic})
+      :telemetry.execute([:gnat, :message_received], 1, %{topic: topic})
       send state.receivers[sid].recipient, {:msg, %{topic: topic, body: body, reply_to: reply_to, sid: sid, gnat: self()}}
       update_subscriptions_after_delivering_message(state, sid)
     else

--- a/mix.lock
+++ b/mix.lock
@@ -12,5 +12,5 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "propcheck": {:hex, :propcheck, "1.1.2", "6ec0e74cfd535ee3923c359f1f1f572451d9915faf9b8312245993e42edd7c84", [:mix], [{:proper, "~> 1.2", [hex: :proper, repo: "hexpm", optional: false]}], "hexpm"},
   "proper": {:hex, :proper, "1.3.0", "c1acd51c51da17a2fe91d7a6fc6a0c25a6a9849d8dc77093533109d1218d8457", [:make, :mix, :rebar3], [], "hexpm"},
-  "telemetry": {:hex, :telemetry, "0.2.0", "5b40caa3efe4deb30fb12d7cd8ed4f556f6d6bd15c374c2366772161311ce377", [:mix], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.3.0", "099a7f3ce31e4780f971b4630a3c22ec66d22208bc090fe33a2a3a6a67754a73", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
I attempted to use gnat in a new app and added the `telemetry` dep set to version `~> 0.2`.  This resolved to the new version `0.3.0`, which has been [rewritten in Erlang](https://github.com/beam-telemetry/telemetry/commit/debf33ef623733dccc3edaa9fe9e42e33eb98caa), so I had to either lock the version at 0.2 or change all the telemetry calls.

This PR updates the internal telemetry calls to (hopefully) work with `0.3.0`.