### PR TITLE
updates to telemetry 0.4

### DIFF
--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -161,8 +161,7 @@ defmodule Gnat do
   def unsub(pid, sid, opts \\ []) do
     start = :erlang.monotonic_time()
     result = GenServer.call(pid, {:unsub, sid, opts})
-    latency = :erlang.monotonic_time() - start
-    :telemetry.execute([:gnat, :unsub], %{latency: latency})
+    :telemetry.execute([:gnat, :unsub], %{latency: :erlang.monotonic_time() - start})
     result
   end
 

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -75,7 +75,8 @@ defmodule Gnat do
   def sub(pid, subscriber, topic, opts \\ []) do
     start = :erlang.monotonic_time()
     result = GenServer.call(pid, {:sub, subscriber, topic, opts})
-    :telemetry.execute([:gnat, :sub], :erlang.monotonic_time() - start, %{topic: topic})
+    latency = :erlang.monotonic_time() - start
+    :telemetry.execute([:gnat, :sub], %{latency: latency}, %{topic: topic})
     result
   end
 
@@ -99,7 +100,8 @@ defmodule Gnat do
   def pub(pid, topic, message, opts \\ []) do
     start = :erlang.monotonic_time()
     result = GenServer.call(pid, {:pub, topic, message, opts})
-    :telemetry.execute([:gnat, :pub], :erlang.monotonic_time() - start, %{topic: topic})
+    latency = :erlang.monotonic_time() - start
+    :telemetry.execute([:gnat, :pub], %{latency: latency} , %{topic: topic})
     result
   end
 
@@ -131,7 +133,8 @@ defmodule Gnat do
         {:error, :timeout}
     end
     :ok = unsub(pid, subscription)
-    :telemetry.execute([:gnat, :request], :erlang.monotonic_time() - start, %{topic: topic})
+    latency = :erlang.monotonic_time() - start
+    :telemetry.execute([:gnat, :request],  %{latency: latency}, %{topic: topic})
     response
   end
 
@@ -158,7 +161,8 @@ defmodule Gnat do
   def unsub(pid, sid, opts \\ []) do
     start = :erlang.monotonic_time()
     result = GenServer.call(pid, {:unsub, sid, opts})
-    :telemetry.execute([:gnat, :unsub], :erlang.monotonic_time() - start)
+    latency = :erlang.monotonic_time() - start
+    :telemetry.execute([:gnat, :unsub], %{latency: latency})
     result
   end
 
@@ -335,7 +339,7 @@ defmodule Gnat do
   end
   defp process_message({:msg, topic, sid, reply_to, body}, state) do
     unless is_nil(state.receivers[sid]) do
-      :telemetry.execute([:gnat, :message_received], 1, %{topic: topic})
+      :telemetry.execute([:gnat, :message_received], %{latency: 1}, %{topic: topic})
       send state.receivers[sid].recipient, {:msg, %{topic: topic, body: body, reply_to: reply_to, sid: sid, gnat: self()}}
       update_subscriptions_after_delivering_message(state, sid)
     else

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Gnat.Mixfile do
       {:jason, "~> 1.1"},
       {:nimble_parsec, "~> 0.5"},
       {:propcheck, "~> 1.0", only: :test},
-      {:telemetry, "~> 0.3"}
+      {:telemetry, "~> 0.4"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -12,5 +12,5 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "propcheck": {:hex, :propcheck, "1.1.3", "d7939f5590607127686894e016286cfe34cebb74eaa553e4321c6e488e9cd1f4", [:mix], [{:proper, "~> 1.3", [hex: :proper, repo: "hexpm", optional: false]}], "hexpm"},
   "proper": {:hex, :proper, "1.3.0", "c1acd51c51da17a2fe91d7a6fc6a0c25a6a9849d8dc77093533109d1218d8457", [:make, :mix, :rebar3], [], "hexpm"},
-  "telemetry": {:hex, :telemetry, "0.3.0", "099a7f3ce31e4780f971b4630a3c22ec66d22208bc090fe33a2a3a6a67754a73", [:rebar3], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
Updates telemetry to newest version and removes warnings about deprecated execute/3 with an int 2ng arg. Now uses maps instead