### PR TITLE
report count measurement, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Gnat uses [telemetry](https://hex.pm/packages/telemetry) to make instrumentation
 If you want to record metrics around the number of messages or latency of message publishes, subscribes, requests, etc you can do the following in your project:
 
 ```elixir
-iex(1)> metrics_function = fn(event_name, event_value, event_meta, config) ->
-  IO.inspect([event_name, event_value, event_meta, config])
+iex(1)> metrics_function = fn(event_name, measurements, event_meta, config) ->
+  IO.inspect([event_name, measurements, event_meta, config])
   :ok
 end
 #Function<4.128620087/4 in :erl_eval.expr/5>
@@ -46,16 +46,16 @@ iex(3)> :telemetry.attach_many("my listener", names, metrics_function, %{my_conf
 iex(4)> {:ok, gnat} = Gnat.start_link()
 {:ok, #PID<0.203.0>}
 iex(5)> Gnat.sub(gnat, self(), "topic")
-[[:gnat, :sub], 128000, %{topic: "topic"}, %{my_config: true}]
+[[:gnat, :sub], %{latency: 128000}, %{topic: "topic"}, %{my_config: true}]
 {:ok, 1}
 iex(6)> Gnat.pub(gnat, "topic", "ohai")
-[[:gnat, :pub], 117000, %{topic: "topic"}, %{my_config: true}]
-[[:gnat, :message_received], 1, %{topic: "topic"}, %{my_config: true}]
+[[:gnat, :pub], %{latency: 117000}, %{topic: "topic"}, %{my_config: true}]
+[[:gnat, :message_received], %{count: 1}, %{topic: "topic"}, %{my_config: true}]
 :ok
 ```
 
 The `pub`, `sub`, `request`, and `unsub` events all report the latency of those respective calls.
-The `message_received` event always reports a value of `1` because there isn't a good latency metric to report.
+The `message_received` event reports a number of messages like `%{count: 1}` because there isn't a good latency metric to report.
 All of the events (except `unsub`) include metadata with a `:topic` key so you can split your metrics by topic.
 
 ## Benchmarks

--- a/lib/gnat.ex
+++ b/lib/gnat.ex
@@ -338,7 +338,7 @@ defmodule Gnat do
   end
   defp process_message({:msg, topic, sid, reply_to, body}, state) do
     unless is_nil(state.receivers[sid]) do
-      :telemetry.execute([:gnat, :message_received], %{latency: 1}, %{topic: topic})
+      :telemetry.execute([:gnat, :message_received], %{count: 1}, %{topic: topic})
       send state.receivers[sid].recipient, {:msg, %{topic: topic, body: body, reply_to: reply_to, sid: sid, gnat: self()}}
       update_subscriptions_after_delivering_message(state, sid)
     else

--- a/test/gnat_property_test.exs
+++ b/test/gnat_property_test.exs
@@ -33,6 +33,7 @@ defmodule GnatPropertyTest do
   property "auto-unsubscribes after n messages" do
     numtests(@numtests, forall {%{subject: subject, payload: payload}, max_messages} <- {message(), pos_integer()} do
       {:ok, ref} = Gnat.sub(:test_connection, self(), subject)
+      :timer.sleep(10)
       :ok = Gnat.unsub(:test_connection, ref, max_messages: max_messages)
       Enum.each(1..max_messages, fn(_) ->
         {:ok, 2} = Gnat.active_subscriptions(:test_connection)


### PR DESCRIPTION
Builds off of #86

Mostly just some updates to the README, I also changed the measurements for the `message_received` event to be a `count` instead of a `latency`. I'm trying to avoid the flakey auto-unub tests by giving 10ms for the server to finish registering our subscription before we start publishing messages.